### PR TITLE
Fix failure to get the history of multiple files if some of them are Added

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -484,7 +484,8 @@ bool FPlasticUpdateStatusWorker::Execute(FPlasticSourceControlCommand& InCommand
 					FString& File = InCommand.Files[IdxFile];
 					FPlasticSourceControlState& State = States[IdxFile];
 
-					if (State.IsSourceControlled())
+					// Cannot fetch the history of file not already submitted to source control
+					if (State.IsSourceControlled() && !State.IsAdded())
 					{
 						// Get the history of the file (on all branches)
 						InCommand.bCommandSuccessful &= PlasticSourceControlUtils::RunGetHistory(File, InCommand.ErrorMessages, State);


### PR DESCRIPTION
Cannot fetch the history of file not already submitted to source control