### PR TITLE
1002000 Implement ISourceControlProvider::UsesFileRevisions() recently added to ue5-main

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
@@ -429,6 +429,16 @@ bool FPlasticSourceControlProvider::UsesFileRevisions() const
 	return IsPartialWorkspace();
 }
 
+TOptional<bool> FPlasticSourceControlProvider::IsAtLatestRevision() const
+{
+	return TOptional<bool>(); // NOTE: used by code in UE5's Status Bar but currently dormant as far as I can tell
+}
+
+TOptional<int> FPlasticSourceControlProvider::GetNumLocalChanges() const
+{
+	return TOptional<int>(); // NOTE: used by code in UE5's Status Bar but currently dormant as far as I can tell
+}
+
 TSharedPtr<IPlasticSourceControlWorker, ESPMode::ThreadSafe> FPlasticSourceControlProvider::CreateWorker(const FName& InOperationName)
 {
 	const FGetPlasticSourceControlWorker* Operation = WorkersMap.Find(InOperationName);

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
@@ -423,6 +423,12 @@ bool FPlasticSourceControlProvider::UsesCheckout() const
 	return GetDefault<UPlasticSourceControlProjectSettings>()->bPromptForCheckoutOnChange;
 }
 
+bool FPlasticSourceControlProvider::UsesFileRevisions() const
+{
+	// Only a partial workspace can sync files individually like Perforce, a regular workspace needs to update completely
+	return IsPartialWorkspace();
+}
+
 TSharedPtr<IPlasticSourceControlWorker, ESPMode::ThreadSafe> FPlasticSourceControlProvider::CreateWorker(const FName& InOperationName)
 {
 	const FGetPlasticSourceControlWorker* Operation = WorkersMap.Find(InOperationName);

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
@@ -187,13 +187,13 @@ FText FPlasticSourceControlProvider::GetStatusText() const
 	Args.Add(TEXT("WorkspaceName"), FText::FromString(WorkspaceName));
 	Args.Add(TEXT("BranchName"), FText::FromString(BranchName));
 	// Detect special case for a partial checkout (CS:-1 in Gluon mode)!
-	if (-1 != ChangesetNumber)
+	if (IsPartialWorkspace())
 	{
-		Args.Add(TEXT("ChangesetNumber"), FText::FromString(FString::Printf(TEXT("%d  (regular full workspace)"), ChangesetNumber)));
+		Args.Add(TEXT("ChangesetNumber"), FText::FromString(FString::Printf(TEXT("N/A  (Gluon partial workspace)"))));
 	}
 	else
 	{
-		Args.Add(TEXT("ChangesetNumber"), FText::FromString(FString::Printf(TEXT("N/A  (Gluon/partial workspace)"))));
+		Args.Add(TEXT("ChangesetNumber"), FText::FromString(FString::Printf(TEXT("%d  (regular full workspace)"), ChangesetNumber)));
 	}
 	Args.Add(TEXT("UserName"), FText::FromString(UserName));
 	const FString DisplayName = PlasticSourceControlUtils::UserNameToDisplayName(UserName);

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.h
@@ -122,6 +122,12 @@ public:
 		return ChangesetNumber;
 	}
 
+	/** A partial/Gluon workspace doesn't match with a single changeset, which is identified by -1 */
+	inline bool IsPartialWorkspace() const
+	{
+		return (ChangesetNumber == -1);
+	}
+
 	/** Version of the Plastic SCM executable used */
 	inline const FSoftwareVersion& GetPlasticScmVersion() const
 	{

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.h
@@ -52,6 +52,7 @@ public:
 	virtual bool UsesLocalReadOnlyState() const override;
 	virtual bool UsesChangelists() const override;
 	virtual bool UsesCheckout() const override;
+	virtual bool UsesFileRevisions() const; /* override				NOTE: added in UE5.1 */
 	virtual void Tick() override;
 	virtual TArray< TSharedRef<class ISourceControlLabel> > GetLabels(const FString& InMatchingSpec) const override;
 #if ENGINE_MAJOR_VERSION == 5

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.h
@@ -53,6 +53,8 @@ public:
 	virtual bool UsesChangelists() const override;
 	virtual bool UsesCheckout() const override;
 	virtual bool UsesFileRevisions() const; /* override				NOTE: added in UE5.1 */
+	virtual TOptional<bool> IsAtLatestRevision() const; /* override	NOTE: added in UE5.1 */
+	virtual TOptional<int> GetNumLocalChanges() const; /* override	NOTE: added in UE5.1 */
 	virtual void Tick() override;
 	virtual TArray< TSharedRef<class ISourceControlLabel> > GetLabels(const FString& InMatchingSpec) const override;
 #if ENGINE_MAJOR_VERSION == 5


### PR DESCRIPTION

See Commit https://github.com/EpicGames/UnrealEngine/commit/286e2234 by wouter burgers, 09/20/2022 03:54 AM
SourceControl / UEFN: Remove / disable 'sync' context menu item in Content Browser.
For SourceControl providers that do not support individual file revisions, the 'Sync' option in the context menu of the Content Browser is misleading as it suggests only the selected files/folders will be synced, while in reality the sync is project wide. I've left the current behavior as the default behavior for all but Skein/Git of which I know they do not support individual file revisions.

Plastic SCM is in fact only capable of syncing an asset or a folder in Gluon/partial workspace mode, not on regular full workspaces