### PR TITLE
Apply to "RevertUnchanged" the same optimization as for "Sync"

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -652,6 +652,12 @@ bool FPlasticRevertUnchangedWorker::Execute(FPlasticSourceControlCommand& InComm
 	{
 		Files.Add(FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()));
 	}
+	// detect the special case of a Sync of the root folder:
+	else if ((InCommand.Files.Num() == 1) && (InCommand.Files[0] == InCommand.PathToWorkspaceRoot))
+	{
+		// only update the status of assets in the Content directory
+		Files[0] = FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir());
+	}
 	PlasticSourceControlUtils::RunUpdateStatus(Files, false, InCommand.Concurrency, InCommand.ErrorMessages, States, InCommand.ChangesetNumber, InCommand.BranchName);
 
 	return InCommand.bCommandSuccessful;
@@ -1043,7 +1049,7 @@ bool FPlasticSyncWorker::Execute(FPlasticSourceControlCommand& InCommand)
 	{
 		// now update the status of our files
 		// detect the special case of a Sync of the root folder:
-		if ((InCommand.Files.Num() == 1) && (InCommand.Files.Last() == InCommand.PathToWorkspaceRoot))
+		if ((InCommand.Files.Num() == 1) && (InCommand.Files[0] == InCommand.PathToWorkspaceRoot))
 		{
 			// only update the status of assets in the Content directory
 			TArray<FString> ContentDir;


### PR DESCRIPTION
FPlasticRevertUnchangedWorker::Execute() now detects the special case of a Sync of the root folder and only update the status of assets in the Content directory, like FPlasticSyncWorker::Execute() does