### PR TITLE
Implement UsesLocalReadOnlyState() based on Plastic SCM config value for SetFilesAsReadOnly

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
@@ -111,6 +111,8 @@ void FPlasticSourceControlProvider::CheckPlasticAvailability()
 			return;
 		}
 
+		bUsesLocalReadOnlyState = PlasticSourceControlUtils::GetConfigSetFilesAsReadOnly();
+
 		// Get user name (from the global Plastic SCM client config)
 		PlasticSourceControlUtils::GetUserName(UserName);
 
@@ -415,7 +417,7 @@ void FPlasticSourceControlProvider::CancelOperation(const FSourceControlOperatio
 
 bool FPlasticSourceControlProvider::UsesLocalReadOnlyState() const
 {
-	return false; // TODO: use configuration
+	return bUsesLocalReadOnlyState;
 }
 
 bool FPlasticSourceControlProvider::UsesChangelists() const

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.h
@@ -200,6 +200,9 @@ private:
 	/** Indicates if source control integration is available or not. */
 	bool bServerAvailable = false;
 
+	/** Whether Plastic SCM is configure to uses local read-only state to signal whether a file is editable. */
+	bool bUsesLocalReadOnlyState = false;
+
 	/** Critical section for thread safety of error messages that occurred after last Plastic command */
 	mutable FCriticalSection LastErrorsCriticalSection;
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -103,6 +103,23 @@ bool GetPlasticScmVersion(FSoftwareVersion& OutPlasticScmVersion)
 	return false;
 }
 
+bool GetConfigSetFilesAsReadOnly()
+{
+	TArray<FString> InfoMessages;
+	TArray<FString> ErrorMessages;
+	TArray<FString> Parameters;
+	Parameters.Add(TEXT("setfileasreadonly"));
+	const bool bResult = RunCommand(TEXT("getconfig"), Parameters, TArray<FString>(), EConcurrency::Synchronous, InfoMessages, ErrorMessages);
+	if (bResult && InfoMessages.Num() > 0)
+	{
+		if ((InfoMessages[0].Compare("yes", ESearchCase::IgnoreCase) == 0) || (InfoMessages[0].Compare("true", ESearchCase::IgnoreCase) == 0))
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
 void GetUserName(FString& OutUserName)
 {
 	TArray<FString> InfoMessages;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
@@ -38,6 +38,12 @@ bool GetWorkspacePath(const FString& InPathToGameDir, FString& OutWorkspaceRoot)
 bool GetPlasticScmVersion(FSoftwareVersion& OutPlasticScmVersion);
 
 /**
+ * Get Plastic SCM config value for SetFilesAsReadOnly
+ * @returns true if configure to use read-only flags on file that are not checked-out ("protected").
+*/
+bool GetConfigSetFilesAsReadOnly();
+
+/**
  * Get Plastic SCM current user
  * @param	OutUserName			Name of the Plastic SCM user configured globally
  */


### PR DESCRIPTION
Check whether Plastic SCM uses read-only flags to mark files after update or checkin in order to "protect" them from anyone to edit them

This triggers Unreal Editor to popup and ask the user if they want to Checkout or just Mark the file Writable locally