### PR TITLE
Fix shared collection: assumes that the default source control status 'Unknown' is "in source control"

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
@@ -519,9 +519,10 @@ bool FPlasticSourceControlState::IsCurrent() const
 
 bool FPlasticSourceControlState::IsSourceControlled() const
 {
+	// NOTE: the Editor Collections rely on the default 'Unknown' state (until the actual file status is obtained) to be considered "in source control"
 	const bool bIsSourceControlled = WorkspaceState != EWorkspaceState::Private
-								  && WorkspaceState != EWorkspaceState::Ignored
-								  && WorkspaceState != EWorkspaceState::Unknown;
+								  && WorkspaceState != EWorkspaceState::Ignored;
+								  // WorkspaceState != EWorkspaceState::Unknown 
 
 	if (!bIsSourceControlled && !IsUnknown()) UE_LOG(LogSourceControl, Log, TEXT("%s NOT SourceControlled"), *LocalFilename);
 


### PR DESCRIPTION
I had to debug the Perforce plugin to understand that this part of the Editor rely on the fact that "Collections" (".collection" files) are always in source control and never changed locally since the Editor does auto checkout+change+checkin

The Perforce plugin assumes that all files are in the "DontCare" state by default that is either 'Unknown' OR 'Controlled' (vs the Plastic SCM plugin uses a dedicated 'Unknown' state). I think I'll have to drop the Unknown state and mimic the behavior of the Perforce plugin going forward