### PR TITLE
Limit the size of the history for performance reasons

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,9 @@ EnableVerboseLogs=False
 
 Unreal Engine allows you to configure project-related settings.
 
-- TODO: Some are not yet supported by the plugin (eg Delete on Revert)
+- TODO: Some are not yet supported by the plugin
+- **Should Delete New Files on Revert**
+- **Enable Uncontrolled Changelists**
 
 ![Project Settings - Source Control](Screenshots/UEPlasticPlugin-ProjectSettingsSourceControl.png)
 
@@ -172,10 +174,12 @@ There are 3 settings available at the moment:
  - **Hide Email Domain in Username**
    - This setting toggles the visibility of domain names in user names, if the user name is an email.
  - **Prompt for Checkout on Change**
-   - Unchecking this setting will make the Editor consider all files as already checked out. In that case, you won't get
+   - Un-checking this setting will make the Editor consider all files as already checked out. In that case, you won't get
      any notifications when you modify assets, and the "Checkout Assets" dialog won't show when you save those changes.
      This mimics how Git works, i.e. allowing the user to perform changes without worrying about checking out items.
      Note: Changelists don't currently support locally changed assets (ie not checked-out)
+ - **Limit Number of Revisions in History**
+   - If a non-null value is set, limit the maximum number of revisions requested to Plastic SCM to display in the "History" window.
 
 #### Editor Preferences
 
@@ -476,8 +480,9 @@ This version here is the development version, so it always contains additional f
  - Windows only
 
 ### Feature Requests
- - Unreal Engine 5.0 full support
+ - Unreal Engine 5.1 full support
    - Shelves of Changelists
+   - Uncontrolled Changelists
  - Mac OS X Support
  - add a menu entry to switch the workspace to Partial
  - add a setting to configure Plastic SCM to use "read-only flags" like Perforce

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ EnableVerboseLogs=False
 
 Unreal Engine allows you to configure project-related settings.
 
-- TODO: Some are not yet supported by the plugin
+TODO: Some are not yet supported by the plugin:
 - **Should Delete New Files on Revert**
 - **Enable Uncontrolled Changelists**
 
@@ -171,15 +171,16 @@ There are 3 settings available at the moment:
 
  - **User Name to Display Name**
    - For each entry in this dictionary, the Editor will replace the user name in the key with the display value you specify.
- - **Hide Email Domain in Username**
+ - **Hide Email Domain in Username** (true by default)
    - This setting toggles the visibility of domain names in user names, if the user name is an email.
- - **Prompt for Checkout on Change**
+ - **Prompt for Checkout on Change** (true by default)
    - Un-checking this setting will make the Editor consider all files as already checked out. In that case, you won't get
      any notifications when you modify assets, and the "Checkout Assets" dialog won't show when you save those changes.
      This mimics how Git works, i.e. allowing the user to perform changes without worrying about checking out items.
      Note: Changelists don't currently support locally changed assets (ie not checked-out)
- - **Limit Number of Revisions in History**
+ - **Limit Number Of Revisions in History** (50 by default)
    - If a non-null value is set, limit the maximum number of revisions requested to Plastic SCM to display in the "History" window.
+   - Requires [Plastic SCM 11.0.16.7608](https://www.plasticscm.com/download/releasenotes/11.0.16.7608) that added support for history --limit
 
 #### Editor Preferences
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -8,6 +8,7 @@
 #include "PlasticSourceControlSettings.h"
 #include "PlasticSourceControlState.h"
 #include "PlasticSourceControlUtils.h"
+#include "PlasticSourceControlVersions.h"
 #include "ScopedTempFile.h"
 
 #include "AssetRegistry/AssetRegistryModule.h"
@@ -19,14 +20,6 @@
 #include "Algo/NoneOf.h"
 
 #define LOCTEXT_NAMESPACE "PlasticSourceControl"
-
-#if ENGINE_MAJOR_VERSION == 5
-
-// 11.0.16.7248 add support for --descriptionfile for multi-line descriptions and support for special characters
-// https://www.plasticscm.com/download/releasenotes/11.0.16.7248
-static const FSoftwareVersion s_NewChangelistFileArgsPlasticScmVersion(TEXT("11.0.16.7248"));
-
-#endif
 
 template<typename Type>
 static FPlasticSourceControlWorkerRef InstantiateWorker(FPlasticSourceControlProvider& PlasticSourceControlProvider)
@@ -251,7 +244,7 @@ bool DeleteChangelist(const FPlasticSourceControlProvider& PlasticSourceControlP
 {
 	TArray<FString> Parameters;
 	TArray<FString> Files;
-	if (PlasticSourceControlProvider.GetPlasticScmVersion() < s_NewChangelistFileArgsPlasticScmVersion)
+	if (PlasticSourceControlProvider.GetPlasticScmVersion() < PlasticSourceControlVersions::NewChangelistFileArgs)
 	{
 		Parameters.Add(TEXT("rm"));
 		Files.Add(InChangelist.GetName());
@@ -1249,7 +1242,7 @@ FPlasticSourceControlChangelist CreatePendingChangelist(FPlasticSourceControlPro
 
 	bool bCommandSuccessful;
 	TArray<FString> Parameters;
-	if (PlasticSourceControlProvider.GetPlasticScmVersion() < s_NewChangelistFileArgsPlasticScmVersion)
+	if (PlasticSourceControlProvider.GetPlasticScmVersion() < PlasticSourceControlVersions::NewChangelistFileArgs)
 	{
 		Parameters.Add(TEXT("add"));
 		Parameters.Add(TEXT("\"") + NewChangelist.GetName() + TEXT("\""));
@@ -1280,7 +1273,7 @@ bool EditChangelistDescription(const FPlasticSourceControlProvider& PlasticSourc
 {
 	TArray<FString> Parameters;
 	Parameters.Add(TEXT("edit"));
-	if (PlasticSourceControlProvider.GetPlasticScmVersion() < s_NewChangelistFileArgsPlasticScmVersion)
+	if (PlasticSourceControlProvider.GetPlasticScmVersion() < PlasticSourceControlVersions::NewChangelistFileArgs)
 	{
 		Parameters.Add(TEXT("\"") + InChangelist.GetName() + TEXT("\""));
 		Parameters.Add(TEXT("description"));
@@ -1304,7 +1297,7 @@ bool MoveFilesToChangelist(const FPlasticSourceControlProvider& PlasticSourceCon
 	if (InFiles.Num() > 0)
 	{
 		TArray<FString> Parameters;
-		if (PlasticSourceControlProvider.GetPlasticScmVersion() < s_NewChangelistFileArgsPlasticScmVersion)
+		if (PlasticSourceControlProvider.GetPlasticScmVersion() < PlasticSourceControlVersions::NewChangelistFileArgs)
 		{
 			Parameters.Add(TEXT("\"") + InChangelist.GetName() + TEXT("\""));
 			Parameters.Add(TEXT("add"));
@@ -1342,7 +1335,7 @@ bool FPlasticNewChangelistWorker::Execute(class FPlasticSourceControlCommand& In
 
 	FString Description = Operation->GetDescription().ToString();
 	// Note: old "cm" doesn't support newlines, quotes, and question marks on changelist's name or description
-	if (GetProvider().GetPlasticScmVersion() < s_NewChangelistFileArgsPlasticScmVersion)
+	if (GetProvider().GetPlasticScmVersion() < PlasticSourceControlVersions::NewChangelistFileArgs)
 	{
 		Description.ReplaceInline(TEXT("\r\n"), TEXT(" "), ESearchCase::CaseSensitive);
 		Description.ReplaceCharInline(TEXT('\n'), TEXT(' '), ESearchCase::CaseSensitive);
@@ -1479,7 +1472,7 @@ bool FPlasticEditChangelistWorker::Execute(class FPlasticSourceControlCommand& I
 
 	EditedDescription = Operation->GetDescription().ToString();
 	// Note: old "cm" doesn't support newlines, quotes, and question marks on changelist's name or description
-	if (GetProvider().GetPlasticScmVersion() < s_NewChangelistFileArgsPlasticScmVersion)
+	if (GetProvider().GetPlasticScmVersion() < PlasticSourceControlVersions::NewChangelistFileArgs)
 	{
 		EditedDescription.ReplaceInline(TEXT("\r\n"), TEXT(" "), ESearchCase::CaseSensitive);
 		EditedDescription.ReplaceCharInline(TEXT('\n'), TEXT(' '), ESearchCase::CaseSensitive);

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -24,7 +24,7 @@
 
 // 11.0.16.7248 add support for --descriptionfile for multi-line descriptions and support for special characters
 // https://www.plasticscm.com/download/releasenotes/11.0.16.7248
-static const FSoftwareVersion s_NewChangelistFileArgsPlasticScmVersion(11, 0, 16, 7248);
+static const FSoftwareVersion s_NewChangelistFileArgsPlasticScmVersion(TEXT("11.0.16.7248"));
 
 #endif
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProjectSettings.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProjectSettings.h
@@ -24,4 +24,8 @@ public:
 	/** If enabled, you'll be prompted to check out changed files (enabled by default). Checkout is needed to work with Changelists. */
 	UPROPERTY(config, EditAnywhere, Category = "Plastic SCM")
 	bool bPromptForCheckoutOnChange = true;
+
+	/** If a non-null value is set, limit the maximum number of revisions requested to Plastic SCM to display in the "History" window. */
+	UPROPERTY(config, EditAnywhere, Category = "Plastic SCM", meta=(ClampMin=0))
+	int32 LimitNumberOfRevisionsInHistory = 50;
 };

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -9,6 +9,7 @@
 #include "PlasticSourceControlSettings.h"
 #include "PlasticSourceControlShell.h"
 #include "PlasticSourceControlState.h"
+#include "PlasticSourceControlVersions.h"
 #include "ISourceControlModule.h"
 #include "ScopedTempFile.h"
 
@@ -32,11 +33,6 @@
 namespace PlasticSourceControlUtils
 {
 
-// 11.0.16.7608 add support for history --limit. It displays the N last revisions of the specified items.
-// https://www.plasticscm.com/download/releasenotes/11.0.16.7608
-static const FSoftwareVersion s_NewHistoryLimitPlasticScmVersion(TEXT("11.0.16.7608"));
-
-
 // Run a command and return the result as raw strings
 bool RunCommand(const FString& InCommand, const TArray<FString>& InParameters, const TArray<FString>& InFiles, FString& OutResults, FString& OutErrors)
 {
@@ -59,9 +55,7 @@ bool RunCommand(const FString& InCommand, const TArray<FString>& InParameters, c
 
 const FSoftwareVersion& GetOldestSupportedPlasticScmVersion()
 {
-	// https://www.plasticscm.com/download/releasenotes/9.0.16.4839 cm changelist 'persistent' flag now contain a '--' prefix.
-	static FSoftwareVersion s_OldestSupportedPlasticScmVersion(TEXT("9.0.16.4839"));
-	return s_OldestSupportedPlasticScmVersion;
+	return PlasticSourceControlVersions::OldestSupported;
 }
 
 FString FindPlasticBinaryPath()
@@ -1344,7 +1338,7 @@ bool RunGetHistory(const bool bInUpdateHistory, TArray<FPlasticSourceControlStat
 	Parameters.Add(TEXT("--xml"));
 	Parameters.Add(TEXT("--encoding=\"utf-8\""));
 	const FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
-	if (Provider.GetPlasticScmVersion() >= s_NewHistoryLimitPlasticScmVersion)
+	if (Provider.GetPlasticScmVersion() >= PlasticSourceControlVersions::NewHistoryLimit)
 	{
 		if (bInUpdateHistory)
 		{

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtilsTests.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtilsTests.cpp
@@ -47,7 +47,17 @@ bool FSoftwareVersionEqualUnitTest::RunTest(const FString& Parameters)
 	FSoftwareVersion VersionParse(TEXT("1.2.3.4"));
 	FSoftwareVersion VersionSplit(1, 2, 3, 4);
 
-	TestTrue(TEXT("Equal"), VersionParse == VersionSplit);
+	FSoftwareVersion VersionZero(TEXT("0.0.0.0"));
+
+	TestTrue(TEXT("Equal"), VersionSplit == VersionParse);
+	TestTrue(TEXT("Equal"), VersionParse == VersionParse);
+	TestTrue(TEXT("Equal"), VersionSplit == VersionSplit);
+
+	TestFalse(TEXT("Different"), VersionParse == VersionZero);
+	TestFalse(TEXT("Different"), VersionParse == FSoftwareVersion(TEXT("0.2.3.4")));
+	TestFalse(TEXT("Different"), VersionParse == FSoftwareVersion(TEXT("1.0.3.4")));
+	TestFalse(TEXT("Different"), VersionParse == FSoftwareVersion(TEXT("1.2.0.4")));
+	TestFalse(TEXT("Different"), VersionParse == FSoftwareVersion(TEXT("1.2.3.0")));
 
 	return true; // actual results are returned by TestXxx() macros
 }
@@ -94,6 +104,40 @@ bool FSoftwareVersionLessUnitTest::RunTest(const FString& Parameters)
 	TestFalse(TEXT("Changeset difference"), VersionEleven4 < VersionEleven3);
 	TestFalse(TEXT("Changeset difference"), VersionEleven5 < VersionEleven4);
 	TestFalse(TEXT("Changeset difference"), VersionEleven6 < VersionEleven5);
+
+	return true; // actual results are returned by TestXxx() macros
+}
+
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSoftwareVersionMoreOrEqualUnitTest, "PlasticSCM.SoftwareVersionMoreOrEqual", EAutomationTestFlags::ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FSoftwareVersionMoreOrEqualUnitTest::RunTest(const FString& Parameters)
+{
+	FSoftwareVersion VersionZero(TEXT("0.0.0.0"));
+	FSoftwareVersion VersionTen(TEXT("10.1.19.9999"));
+	FSoftwareVersion VersionEleven0(TEXT("11.0.15.13"));
+	FSoftwareVersion VersionEleven1(TEXT("11.0.16.13"));
+	FSoftwareVersion VersionEleven2(TEXT("11.0.16.123"));
+	FSoftwareVersion VersionEleven3(TEXT("11.0.16.1111"));
+	FSoftwareVersion VersionEleven4(TEXT("11.0.16.7134"));
+	FSoftwareVersion VersionEleven5(TEXT("11.0.16.9999"));
+	FSoftwareVersion VersionEleven6(TEXT("11.1.0.0"));
+	FSoftwareVersion VersionTwelve(TEXT("12.0.10.0"));
+
+	TestTrue(TEXT("No difference"), VersionZero >= VersionZero);
+	TestTrue(TEXT("No difference"), VersionTen >= VersionTen);
+	TestTrue(TEXT("No difference"), VersionEleven4 >= VersionEleven4);
+
+	TestFalse(TEXT("Major difference"), VersionTen >= VersionEleven1);
+	TestTrue(TEXT("Major difference"), VersionEleven1 >= VersionTen);
+
+	TestFalse(TEXT("Minor difference"), VersionEleven5 >= VersionEleven6);
+	TestTrue(TEXT("Minor difference"), VersionEleven6 >= VersionEleven5);
+
+	TestFalse(TEXT("Patch difference"), VersionEleven0 >= VersionEleven1);
+	TestTrue(TEXT("Patch difference"), VersionEleven1 >= VersionEleven0);
+
+	TestFalse(TEXT("Changeset difference"), VersionEleven1 >= VersionEleven2);
+	TestTrue(TEXT("Changeset difference"), VersionEleven2 >= VersionEleven1);
 
 	return true; // actual results are returned by TestXxx() macros
 }

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtilsTests.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtilsTests.cpp
@@ -40,18 +40,31 @@ bool FFindCommonDirectoryUnitTest::RunTest(const FString& Parameters)
 	return true; // actual results are returned by TestXxx() macros
 }
 
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSoftwareVersionUnitTest, "PlasticSCM.SoftwareVersion", EAutomationTestFlags::ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+
+bool FSoftwareVersionUnitTest::RunTest(const FString& Parameters)
+{
+	FSoftwareVersion VersionParse(TEXT("1.2.3.4"));
+
+	TestEqual(TEXT("Equal Major"), VersionParse.Major, 1);
+	TestEqual(TEXT("Equal Minor"), VersionParse.Minor, 2);
+	TestEqual(TEXT("Equal Patch"), VersionParse.Patch, 3);
+	TestEqual(TEXT("Equal Changeset"), VersionParse.Changeset, 4);
+
+	TestEqual(TEXT("Equal String"), VersionParse.String, TEXT("1.2.3.4"));
+
+	return true; // actual results are returned by TestXxx() macros
+}
+
 IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSoftwareVersionEqualUnitTest, "PlasticSCM.SoftwareVersionEqual", EAutomationTestFlags::ApplicationContextMask | EAutomationTestFlags::ProductFilter)
 
 bool FSoftwareVersionEqualUnitTest::RunTest(const FString& Parameters)
 {
 	FSoftwareVersion VersionParse(TEXT("1.2.3.4"));
-	FSoftwareVersion VersionSplit(1, 2, 3, 4);
-
 	FSoftwareVersion VersionZero(TEXT("0.0.0.0"));
 
-	TestTrue(TEXT("Equal"), VersionSplit == VersionParse);
 	TestTrue(TEXT("Equal"), VersionParse == VersionParse);
-	TestTrue(TEXT("Equal"), VersionSplit == VersionSplit);
+	TestTrue(TEXT("Equal"), VersionParse == FSoftwareVersion(TEXT("1.2.3.4")));
 
 	TestFalse(TEXT("Different"), VersionParse == VersionZero);
 	TestFalse(TEXT("Different"), VersionParse == FSoftwareVersion(TEXT("0.2.3.4")));

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlVersions.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlVersions.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2016-2022 Codice Software
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "SoftwareVersion.h"
+
+/**
+ * Plastic SCM version strings in the form "X.Y.Z.C", ie Major.Minor.Patch.Changeset (as returned by GetPlasticScmVersion)
+*/
+namespace PlasticSourceControlVersions
+{
+	// 11.0.16.7248 add support for --descriptionfile for multi-line descriptions and support for special characters
+	// https://www.plasticscm.com/download/releasenotes/11.0.16.7248
+	static const FSoftwareVersion NewChangelistFileArgs(TEXT("11.0.16.7248"));
+
+	// 11.0.16.7608 add support for history --limit. It displays the N last revisions of the specified items.
+	// https://www.plasticscm.com/download/releasenotes/11.0.16.7608
+	static const FSoftwareVersion NewHistoryLimit(TEXT("11.0.16.7608"));
+
+	// 9.0.16.4839 cm changelist 'persistent' flag now contain a '--' prefix.
+	// https://www.plasticscm.com/download/releasenotes/9.0.16.4839
+	static FSoftwareVersion OldestSupported(TEXT("9.0.16.4839"));
+
+} // namespace PlasticSourceControlVersions

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.cpp
@@ -327,7 +327,7 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 			.OnCheckStateChanged(this, &SPlasticSourceControlSettings::OnCheckedUpdateStatusOtherBranches)
 			[
 				SNew(STextBlock)
-				.Text(LOCTEXT("UpdateStatusOtherBranches", "Update status also check branch history."))
+				.Text(LOCTEXT("UpdateStatusOtherBranches", "Update Status also checks history to detect changes on other branches."))
 				.Font(Font)
 			]
 		]

--- a/Source/PlasticSourceControl/Private/SoftwareVersion.cpp
+++ b/Source/PlasticSourceControl/Private/SoftwareVersion.cpp
@@ -16,15 +16,6 @@ FSoftwareVersion::FSoftwareVersion(FString&& InVersionString)
 	}
 }
 
-FSoftwareVersion::FSoftwareVersion(const int& InMajor, const int& InMinor, const int& InPatch, const int& InChangeset)
-{
-	String = FString::Printf(TEXT("%d.%d.%d.%d"), InMajor, InMinor, InPatch);
-	Major = InMajor;
-	Minor = InMinor;
-	Patch = InPatch;
-	Changeset = InChangeset;
-}
-
 bool operator==(const FSoftwareVersion& Rhs, const FSoftwareVersion& Lhs)
 {
 	return (Rhs.Major == Lhs.Major) && (Rhs.Minor == Lhs.Minor) && (Rhs.Patch == Lhs.Patch) && (Rhs.Changeset == Lhs.Changeset);

--- a/Source/PlasticSourceControl/Private/SoftwareVersion.cpp
+++ b/Source/PlasticSourceControl/Private/SoftwareVersion.cpp
@@ -42,3 +42,8 @@ bool operator<(const FSoftwareVersion& Rhs, const FSoftwareVersion& Lhs)
 	if (Rhs.Changeset > Lhs.Changeset) return false;
 	return false; // Equal
 }
+
+bool operator>=(const FSoftwareVersion& Rhs, const FSoftwareVersion& Lhs)
+{
+	return !(Rhs < Lhs);
+}

--- a/Source/PlasticSourceControl/Private/SoftwareVersion.h
+++ b/Source/PlasticSourceControl/Private/SoftwareVersion.h
@@ -24,3 +24,4 @@ struct FSoftwareVersion
 
 bool operator==(const FSoftwareVersion& Rhs, const FSoftwareVersion& Lhs);
 bool operator<(const FSoftwareVersion& Rhs, const FSoftwareVersion& Lhs);
+bool operator>=(const FSoftwareVersion& Rhs, const FSoftwareVersion& Lhs);

--- a/Source/PlasticSourceControl/Private/SoftwareVersion.h
+++ b/Source/PlasticSourceControl/Private/SoftwareVersion.h
@@ -12,7 +12,6 @@ struct FSoftwareVersion
 	FSoftwareVersion() : String(TEXT("<unknown-version>")) {}
 
 	explicit FSoftwareVersion(FString&& InVersionString);
-	FSoftwareVersion(const int& InMajor, const int& InMinor, const int& InPatch, const int& InChangeset);
 
 	FString String;
 


### PR DESCRIPTION
- Add a new comparison operator >= to SoftwareVersion for convenience
- Fixed a latent bug in SoftwareVersion.String (that was for display purpose only, and only when using one of the two constructors)
- Add a new LimitNumberOfRevisionsInHistory to Plastic SCM's Project Settings
- Use version detection and the above settings to apply the appropriate --limit depending on the situation