### PR TITLE
Fix sync/update workspace in partial workspace

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -1053,7 +1053,7 @@ bool FPlasticSyncWorker::Execute(FPlasticSourceControlCommand& InCommand)
 	TRACE_CPUPROFILER_EVENT_SCOPE(FPlasticSyncWorker::Execute);
 
 	TArray<FString> UpdatedFiles;
-	InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunSync(InCommand.Files, GetProvider().IsPartialWorkspace(), UpdatedFiles, InCommand.ErrorMessages);
+	InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunUpdate(InCommand.Files, GetProvider().IsPartialWorkspace(), UpdatedFiles, InCommand.ErrorMessages);
 
 	// now update the status of the corresponding files
 	if (UpdatedFiles.Num())

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -1395,9 +1395,9 @@ bool RunGetHistory(const bool bInUpdateHistory, TArray<FPlasticSourceControlStat
   </List>
 </UpdatedItems>
 */
-static bool ParseSyncResults(const FXmlFile& InXmlResult, TArray<FString>& OutFiles)
+static bool ParseUpdateResults(const FXmlFile& InXmlResult, TArray<FString>& OutFiles)
 {
-	TRACE_CPUPROFILER_EVENT_SCOPE(PlasticSourceControlUtils::ParseHistoryResults);
+	TRACE_CPUPROFILER_EVENT_SCOPE(PlasticSourceControlUtils::ParseUpdateResults);
 
 	static const FString UpdatedItems(TEXT("UpdatedItems"));
 	static const FString List(TEXT("List"));
@@ -1431,7 +1431,7 @@ static bool ParseSyncResults(const FXmlFile& InXmlResult, TArray<FString>& OutFi
 }
 
 // Run a Plastic "update" command to sync the workspace and parse its XML results.
-bool RunSync(const TArray<FString>& InFiles, const bool bInIsPartialWorkspace, TArray<FString>& OutUpdatedFiles, TArray<FString>& OutErrorMessages)
+bool RunUpdate(const TArray<FString>& InFiles, const bool bInIsPartialWorkspace, TArray<FString>& OutUpdatedFiles, TArray<FString>& OutErrorMessages)
 {
 	bool bResult = false;
 
@@ -1455,16 +1455,16 @@ bool RunSync(const TArray<FString>& InFiles, const bool bInIsPartialWorkspace, T
 			{
 				FXmlFile XmlFile;
 				{
-					TRACE_CPUPROFILER_EVENT_SCOPE(PlasticSourceControlUtils::RunSync::FXmlFile::LoadFile);
+					TRACE_CPUPROFILER_EVENT_SCOPE(PlasticSourceControlUtils::RunUpdate::FXmlFile::LoadFile);
 					bResult = XmlFile.LoadFile(Results, EConstructMethod::ConstructFromBuffer);
 				}
 				if (bResult)
 				{
-					bResult = ParseSyncResults(XmlFile, OutUpdatedFiles);
+					bResult = ParseUpdateResults(XmlFile, OutUpdatedFiles);
 				}
 				else
 				{
-					UE_LOG(LogSourceControl, Error, TEXT("RunSync: XML parse error '%s'"), *XmlFile.GetLastError())
+					UE_LOG(LogSourceControl, Error, TEXT("RunUpdate: XML parse error '%s'"), *XmlFile.GetLastError())
 				}
 			}
 		}

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -1465,13 +1465,13 @@ bool RunUpdate(const TArray<FString>& InFiles, const bool bInIsPartialWorkspace,
 {
 	bool bResult = false;
 
-	TArray<FString> InfoMessages;
 	TArray<FString> Parameters;
 	// Update specified directory to the head of the repository
 	// Detect special case for a partial checkout (CS:-1 in Gluon mode)!
 	if (!bInIsPartialWorkspace)
 	{
 		const FScopedTempFile TempFile;
+		TArray<FString> InfoMessages;
 		Parameters.Add(FString::Printf(TEXT("--xml=\"%s\""), *TempFile.GetFilename()));
 		Parameters.Add(TEXT("--encoding=\"utf-8\""));
 		Parameters.Add(TEXT("--last"));
@@ -1501,12 +1501,13 @@ bool RunUpdate(const TArray<FString>& InFiles, const bool bInIsPartialWorkspace,
 	}
 	else
 	{
+		TArray<FString> Results;
 		Parameters.Add(TEXT("--report"));
 		Parameters.Add(TEXT("--machinereadable"));
-		bResult = PlasticSourceControlUtils::RunCommand(TEXT("partial update"), Parameters, InFiles, InfoMessages, OutErrorMessages);
+		bResult = PlasticSourceControlUtils::RunCommand(TEXT("partial update"), Parameters, InFiles, Results, OutErrorMessages);
 		if (bResult)
 		{
-			bResult = ParseUpdateResults(InfoMessages, OutUpdatedFiles);
+			bResult = ParseUpdateResults(Results, OutUpdatedFiles);
 		}
 	}
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
@@ -160,7 +160,7 @@ bool RunGetHistory(const bool bInUpdateHistory, TArray<FPlasticSourceControlStat
  * @param	OutUpdatedFiles			The files that where updated
  * @param	OutErrorMessages		Any errors (from StdErr) as an array per-line
  */
-bool RunSync(const TArray<FString>& InFiles, const bool bInIsPartialWorkspace, TArray<FString>& OutUpdatedFiles, TArray<FString>& OutErrorMessages);
+bool RunUpdate(const TArray<FString>& InFiles, const bool bInIsPartialWorkspace, TArray<FString>& OutUpdatedFiles, TArray<FString>& OutErrorMessages);
 
 #if ENGINE_MAJOR_VERSION == 5
 


### PR DESCRIPTION
Until recently this operation was crashing in Unreal Engine 5 at the end of the lengthy Reload Package operation.
When I fixed the regular workspace mode, this partial mode ended up not reloading anything anymore (so not crashing either ;)

- Rename RunSync() to RunUpdate() to match with the underlying cm operation (same with ParseUpdateResults())
- Implement a new variant of ParseUpdateResults() variant to parse cm partial update --report --machinereadable