### PR TITLE
Fix cm shell timeout if the cli doesn't have credentials saved

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlShell.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlShell.cpp
@@ -265,7 +265,7 @@ static bool _RunCommandInternal(const FString& InCommand, const TArray<FString>&
 		else if ((FPlatformTime::Seconds() - LastLog > LogInterval) && (PreviousLogLen < OutResults.Len()))
 		{
 			// In case of long running operation, start to print intermediate output from cm shell (like percentage of progress)
-			UE_LOG(LogSourceControl, Log, TEXT("RunCommand: '%s' in progress for %.3lfs...\n%s"), *InCommand, (FPlatformTime::Seconds() - StartTimestamp), *OutResults.Mid(PreviousLogLen));
+			UE_LOG(LogSourceControl, Log, TEXT("RunCommand: '%s' in progress for %.3lfs... (%d chars):\n%s"), *InCommand, (FPlatformTime::Seconds() - StartTimestamp), OutResults.Len() - PreviousLogLen, *OutResults.Mid(PreviousLogLen));
 			PreviousLogLen = OutResults.Len();
 			LastLog = FPlatformTime::Seconds(); // freshen the timestamp of last log
 		}
@@ -278,7 +278,7 @@ static bool _RunCommandInternal(const FString& InCommand, const TArray<FString>&
 		}
 		else if (IsEngineExitRequested())
 		{
-			UE_LOG(LogSourceControl, Warning, TEXT("RunCommand: '%s' Engine Exit was requested after %.3lfs output (%d chars):\n%s"), *InCommand, (FPlatformTime::Seconds() - StartTimestamp), OutResults.Len(), *OutResults.Mid(PreviousLogLen));
+			UE_LOG(LogSourceControl, Warning, TEXT("RunCommand: '%s' Engine Exit was requested after %.3lfs output (%d chars):\n%s"), *InCommand, (FPlatformTime::Seconds() - StartTimestamp), OutResults.Len() - PreviousLogLen, *OutResults.Mid(PreviousLogLen));
 			_ExitBackgroundCommandLineShell();
 		}
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlShell.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlShell.cpp
@@ -173,6 +173,8 @@ void DisplayFailureNotification(const FText& InNotificationText)
 	FNotificationInfo* Info = new FNotificationInfo(InNotificationText);
 	Info->ExpireDuration = 10.0f;
 	FSlateNotificationManager::Get().QueueNotification(Info);
+	// NOTE: all source control operations run in a thread, so we cannot use MessageLog nor Notify() them since they can only be used from the Main/UI thread
+	// FMessageLog("SourceControl").Error(InNotificationText);
 	UE_LOG(LogSourceControl, Error, TEXT("%s"), *InNotificationText.ToString());
 }
 
@@ -252,7 +254,7 @@ static bool _RunCommandInternal(const FString& InCommand, const TArray<FString>&
 			const uint32 IndexPrompt = OutResults.Find(ShellUserInteractText, ESearchCase::CaseSensitive, ESearchDir::FromEnd);
 			if (INDEX_NONE != IndexPrompt)
 			{
-				const FText ShellRequiresInteractionError(LOCTEXT("SourceControlShell_AskAuthenticate", "Plastic SCM command line requires user interaction."));
+				const FText ShellRequiresInteractionError(LOCTEXT("SourceControlShell_AskAuthenticate", "Plastic SCM command line requires user interaction.\nSign in using the Plastic SCM client."));
 				DisplayFailureNotification(ShellRequiresInteractionError);
 
 				// Restart the shell without waiting, it is forever blocked waiting for user input

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlShell.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlShell.cpp
@@ -274,6 +274,8 @@ static bool _RunCommandInternal(const FString& InCommand, const TArray<FString>&
 			// In case of timeout, ask the blocking 'cm shell' process to exit, detach from it and restart it immediately
 			UE_LOG(LogSourceControl, Error, TEXT("RunCommand: '%s' TIMEOUT after %.3lfs output (%d chars):\n%s"), *InCommand, (FPlatformTime::Seconds() - StartTimestamp), OutResults.Len(), *OutResults.Mid(PreviousLogLen));
 			_RestartBackgroundCommandLineShell(true);
+			// Return output results as error so they get propagated to the Message Log window
+			OutErrors = MoveTemp(OutResults);
 			return false;
 		}
 		else if (IsEngineExitRequested())

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -1048,7 +1048,11 @@ bool RunUpdateStatus(const TArray<FString>& InFiles, const bool bInUpdateHistory
 		// (ie. Changed, CheckedOut, Copied, Replaced, Added, Private, Ignored, Deleted, LocallyDeleted, Moved, LocallyMoved)
 		TArray<FPlasticSourceControlState> States;
 		const bool bGroupOk = RunStatus(Group.Value.CommonDir, MoveTemp(Group.Value.Files), OutErrorMessages, States, OutChangeset, OutBranchName);
-		if (bGroupOk && (States.Num() > 0))
+		if (!bGroupOk)
+		{
+			bResults = false;
+		}
+		else if (States.Num() > 0)
 		{
 			// Run a "fileinfo" command to update complementary status information of given files.
 			// (ie RevisionChangeset, RevisionHeadChangeset, RepSpec, LockedBy, LockedWhere)


### PR DESCRIPTION
_RestartBackgroundCommandLineShell() can now Force Exit for cases of timeout since the shell is blocked and won't be able to exit in time anyway
