### PR TITLE
Fix saving a modified asset locally and being able to revert it even if it is locked

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -1229,11 +1229,6 @@ bool FPlasticGetPendingChangelistsWorker::UpdateStates()
 			for (const auto& FileState : OutCLFilesStates[StatusIndex])
 			{
 				TSharedRef<FPlasticSourceControlState, ESPMode::ThreadSafe> CachedFileState = GetProvider().GetStateInternal(FileState.LocalFilename);
-				// Don't override "fileinfo" information and the potential LockedByOther state
-				if (CachedFileState->WorkspaceState != EWorkspaceState::LockedByOther)
-				{
-					CachedFileState->WorkspaceState = FileState.WorkspaceState;
-				}
 				CachedFileState->Changelist = CLStatus.Changelist;
 				ChangelistState->Files.AddUnique(CachedFileState);
 			}

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
@@ -421,19 +421,19 @@ const FDateTime& FPlasticSourceControlState::GetTimeStamp() const
 	return TimeStamp;
 }
 
-// Deleted and Missing assets cannot appear in the Content Browser but does appear in Submit to Source Control Window
 bool FPlasticSourceControlState::CanCheckIn() const
 {
-	const bool bCanCheckIn =
-		  (WorkspaceState == EWorkspaceState::Added
-		|| WorkspaceState == EWorkspaceState::Deleted
-		|| WorkspaceState == EWorkspaceState::LocallyDeleted
-		|| WorkspaceState == EWorkspaceState::Changed
-		|| WorkspaceState == EWorkspaceState::Moved
-		|| WorkspaceState == EWorkspaceState::Copied
-		|| WorkspaceState == EWorkspaceState::Replaced
-		|| WorkspaceState == EWorkspaceState::CheckedOut)
-		&& !IsConflicted() && IsCurrent();
+	// Deleted assets don't appear in the Content Browser but in Submit to Source Control Window
+	const bool bCanCheckIn =  (WorkspaceState == EWorkspaceState::Added
+							|| WorkspaceState == EWorkspaceState::Deleted
+							|| WorkspaceState == EWorkspaceState::LocallyDeleted
+							|| WorkspaceState == EWorkspaceState::Changed
+							|| WorkspaceState == EWorkspaceState::Moved
+							|| WorkspaceState == EWorkspaceState::Copied
+							|| WorkspaceState == EWorkspaceState::Replaced
+							|| WorkspaceState == EWorkspaceState::CheckedOut)
+							&& !IsCheckedOutOther()	// Is not already checked-out elsewhere
+							&& IsCurrent();			// Is up to date (at the revision of the repo)
 
 	if (!IsUnknown())
 	{
@@ -453,7 +453,8 @@ bool FPlasticSourceControlState::CanCheckout() const
 	const bool bCanCheckout  =    (WorkspaceState == EWorkspaceState::Controlled	// In source control, Unmodified
 								|| WorkspaceState == EWorkspaceState::Changed		// In source control, but not checked-out
 								|| WorkspaceState == EWorkspaceState::Replaced)		// In source control, merged, waiting for checkin to conclude the merge
-								&& IsCurrent(); // Is up to date (at the revision of the repo)
+								&& !IsCheckedOutOther()	// Is not already checked-out elsewhere
+								&& IsCurrent();			// Is up to date (at the revision of the repo)
 
 	if (!IsUnknown())
 	{

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
@@ -29,7 +29,6 @@ namespace EWorkspaceState
 		LocallyDeleted, // Missing
 		Changed, // Modified but not CheckedOut
 		Conflicted,
-		LockedByOther, // LockedBy with name of someone else than cm whoami
 		Private, // "Not Controlled"/"Not In Depot"/"Untracked"
 	};
 
@@ -70,6 +69,7 @@ public:
 		PendingMergeSourceChangeset = InState.PendingMergeSourceChangeset;
 		PendingMergeParameters = MoveTemp(InState.PendingMergeParameters);
 		// Update "fileinfo" information only if the command was issued
+		// Don't override "fileinfo" information in case of an optimized/lightweight "whole folder status" triggered by a global Submit Content or Refresh
 		if (InState.DepotRevisionChangeset != INVALID_REVISION)
 		{
 			LockedBy = MoveTemp(InState.LockedBy);
@@ -83,12 +83,6 @@ public:
 			HeadChangeList = MoveTemp(InState.HeadChangeList);
 			HeadUserName = MoveTemp(InState.HeadUserName);
 			HeadModTime = MoveTemp(InState.HeadModTime);
-		}
-		// Don't override "fileinfo" information in case of an optimized/lightweight "whole folder status" triggered by a global Submit Content or Refresh
-		// and regenerate the LockedByOther state based on LockedBy
-		else if (!IsCheckedOut() && !LockedBy.IsEmpty())
-		{
-			WorkspaceState = EWorkspaceState::LockedByOther;
 		}
 		MovedFrom = MoveTemp(InState.MovedFrom);
 		TimeStamp = InState.TimeStamp;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -712,13 +712,6 @@ static void ParseFileinfoResults(const TArray<FString>& InResults, TArray<FPlast
 		FileState.LockedBy = MoveTemp(FileinfoParser.LockedBy);
 		FileState.LockedWhere = MoveTemp(FileinfoParser.LockedWhere);
 
-		// If a file is locked but not checked-out locally (or moved/renamed) this means it is locked by someone else or elsewhere
-		if ((FileState.WorkspaceState != EWorkspaceState::CheckedOut) && (FileState.WorkspaceState != EWorkspaceState::Moved) && !FileState.LockedBy.IsEmpty())
-		{
-			UE_LOG(LogSourceControl, Verbose, TEXT("LockedByOther(%s) by '%s!=%s' (or %s!=%s)"), *File, *FileState.LockedBy, *Provider.GetUserName(), *FileState.LockedWhere, *Provider.GetWorkspaceName());
-			FileState.WorkspaceState = EWorkspaceState::LockedByOther;
-		}
-
 		// debug log (only for the first few files)
 		if (IdxResult < 20)
 		{


### PR DESCRIPTION
- Refactor: Removal of the LockedByOther dedicated state as it is not exclusive to "Changed" locally
- And fix CanCheckIn() and CanCheckout() now that the enum is not exclusive
