### PR TITLE
Implement shelve status: listing shelves and their content

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlChangelistState.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlChangelistState.h
@@ -78,7 +78,9 @@ public:
 
 	TArray<FSourceControlStateRef> Files;
 
-	TArray<FSourceControlStateRef> ShelvedFiles; // TODO: shelves are not yet implemented
+	int32 ShelveId = ISourceControlState::INVALID_REVISION;
+
+	TArray<FSourceControlStateRef> ShelvedFiles; // TODO: shelves
 
 	/** The timestamp of the last update */
 	FDateTime TimeStamp;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -1197,6 +1197,8 @@ bool FPlasticGetPendingChangelistsWorker::Execute(FPlasticSourceControlCommand& 
 						});
 				});
 		}
+
+		InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunGetShelves(OutChangelistsStates, InCommand.ErrorMessages);
 	}
 
 	bCleanupCache = InCommand.bCommandSuccessful;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
@@ -172,6 +172,13 @@ bool RunUpdate(const TArray<FString>& InFiles, const bool bInIsPartialWorkspace,
  */
 bool RunGetChangelists(TArray<FPlasticSourceControlChangelistState>& OutChangelistsStates, TArray<TArray<FPlasticSourceControlState>>& OutCLFilesStates, TArray<FString>& OutErrorMessages);
 
+/**
+ * Run find "shelves where owner='me'" and for each shelve matching a changelist a "diff sh:<ShelveId>" and parse their results.
+ * @param	InOutChangelistsStates	The list of changelists, filled with their shelved files
+ * @param	OutErrorMessages		Any errors (from StdErr) as an array per-line
+ */
+bool RunGetShelves(TArray<FPlasticSourceControlChangelistState>& InOutChangelistsStates, TArray<FString>& OutErrorMessages);
+
 #endif
 
 /**


### PR DESCRIPTION
Look for shelves with comments starting like "ChangelistXXX: " and matching an existing Changelist

Note: at this stage, this will show in UI shelves created manually, but there is not a single "shelve"/"unshelve"/"delete" operation implemented yet.
In practice, it means that we can safely merge that as it won't be visible to the user just yet.