### PR TITLE
Implement the Delete Shelve operation

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
@@ -441,4 +441,25 @@ protected:
 	FPlasticSourceControlChangelist DestinationChangelist;
 };
 
+class FPlasticDeleteShelveWorker final : public IPlasticSourceControlWorker
+{
+public:
+	explicit FPlasticDeleteShelveWorker(FPlasticSourceControlProvider& InSourceControlProvider)
+		: IPlasticSourceControlWorker(InSourceControlProvider)
+	{}
+	virtual ~FPlasticDeleteShelveWorker() = default;
+
+	// IPlasticSourceControlWorker interface
+	virtual FName GetName() const override;
+	virtual bool Execute(FPlasticSourceControlCommand& InCommand) override;
+	virtual bool UpdateStates() override;
+
+protected:
+	/** List of files to remove from shelved files in changelist state */
+	TArray<FString> FilesToRemove;
+
+	/** Changelist to be updated */
+	FPlasticSourceControlChangelist ChangelistToUpdate;
+};
+
 #endif


### PR DESCRIPTION
Note: in Plastic SCM we cannot delete a selection of files from a shelve, only the whole shelve at once
we could later work this around by creating a new shelve with the other files

Note: at this stage, the "shelve" & "unshelve"/ operations are not implemented yet, so this one will only show for matching shelve created manually with the proper comment.
In practice, it means that we can safely merge that as it won't be visible to the user just yet.

Note: for now it's implemented on top of the other PR related to shelves, so look only at the second commit https://github.com/PlasticSCM/UEPlasticPlugin/pull/59/commits/9dd061814a885d1a6a4376dd7378b95bd62d8dd0