### PR TITLE
Implement the Shelve operation

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
@@ -441,6 +441,35 @@ protected:
 	FPlasticSourceControlChangelist DestinationChangelist;
 };
 
+class FPlasticShelveWorker final : public IPlasticSourceControlWorker
+{
+public:
+	explicit FPlasticShelveWorker(FPlasticSourceControlProvider& InSourceControlProvider)
+		: IPlasticSourceControlWorker(InSourceControlProvider)
+	{}
+	virtual ~FPlasticShelveWorker() = default;
+
+	// IPlasticSourceControlWorker interface
+	virtual FName GetName() const override;
+	virtual bool Execute(FPlasticSourceControlCommand& InCommand) override;
+	virtual bool UpdateStates() override;
+
+protected:
+	int32 ShelveId = ISourceControlState::INVALID_REVISION;
+
+	TArray<FString> ShelvedFiles;
+
+	/** Files that were moved to a new changelist if shelving from the Default Changelist */
+	TArray<FString> MovedFiles;
+
+	/** Changelist description if needed */
+	FString ChangelistDescription;
+
+	/** Changelist(s) to be updated */
+	FPlasticSourceControlChangelist InChangelistToUpdate;
+	FPlasticSourceControlChangelist OutChangelistToUpdate;
+};
+
 class FPlasticDeleteShelveWorker final : public IPlasticSourceControlWorker
 {
 public:

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
@@ -44,6 +44,12 @@ public:
 	{
 	}
 
+	FPlasticSourceControlState(FString&& InLocalFilename, EWorkspaceState::Type InWorkspaceState)
+		: LocalFilename(MoveTemp(InLocalFilename))
+		, WorkspaceState(InWorkspaceState)
+	{
+	}
+
 	FPlasticSourceControlState() = delete;
 	FPlasticSourceControlState(const FPlasticSourceControlState& InState) = delete;
 	const FPlasticSourceControlState& operator=(const FPlasticSourceControlState& InState) = delete;


### PR DESCRIPTION
The shelveset command itself is quite simple, but there are a lot of corner cases to consider:

- If the command is issued on the default changelist, we need to create a new changelist, move the files to the new changelist, then shelve the files
- If there was already a shelve, then ensure that the previous shelved files are also put back into the new shelve
- If there was already a shelve, we now have created a new one with updated files, so we must now delete the old one
- In case of failure to shelve, if we had to create a new changelist, move the files back to the default changelist and delete the changelist
