### PR TITLE
Fix double ChangelistXXX prefix on shelve

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -1733,12 +1733,14 @@ bool FPlasticShelveWorker::Execute(FPlasticSourceControlCommand& InCommand)
 
 	if (InCommand.bCommandSuccessful)
 	{
+		ChangelistDescription = *Operation->GetDescription().ToString();
+
 		TArray<FString> Results;
 		TArray<FString> Parameters;
-		ChangelistDescription = FString::Printf(TEXT("Changelist%s: %s"), *Changelist.GetName(), *Operation->GetDescription().ToString());
-		const FScopedTempFile CommitMsgFile(ChangelistDescription);
+		const FString ShelveDescription = FString::Printf(TEXT("Changelist%s: %s"), *Changelist.GetName(), *ChangelistDescription);
+		const FScopedTempFile CommentsFile(ShelveDescription);
 		Parameters.Add(TEXT("create"));
-		Parameters.Add(FString::Printf(TEXT("-commentsfile=\"%s\""), *FPaths::ConvertRelativePathToFull(CommitMsgFile.GetFilename())));
+		Parameters.Add(FString::Printf(TEXT("-commentsfile=\"%s\""), *FPaths::ConvertRelativePathToFull(CommentsFile.GetFilename())));
 		InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("shelveset"), Parameters, FilesToShelve , Results, InCommand.ErrorMessages);
 		if (InCommand.bCommandSuccessful && Results.Num() > 0)
 		{

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -1660,6 +1660,14 @@ bool FPlasticReopenWorker::UpdateStates()
 	}
 }
 
+bool DeleteShelve(const int32 InShelveId, TArray<FString>& OutErrorMessages)
+{
+	TArray<FString> Results;
+	TArray<FString> Parameters;
+	Parameters.Add(TEXT("delete"));
+	Parameters.Add(FString::Printf(TEXT("sh:%d"), InShelveId));
+	return PlasticSourceControlUtils::RunCommand(TEXT("shelveset"), Parameters, TArray<FString>(), Results, OutErrorMessages);
+}
 
 FName FPlasticShelveWorker::GetName() const
 {
@@ -1799,12 +1807,8 @@ bool FPlasticShelveWorker::UpdateStates()
 	// If there was already a shelve, we have now created a new one with updated files, so we must delete the old one
 	if ((DestinationChangelistState->ShelveId != ISourceControlState::INVALID_REVISION) && (ShelveId != DestinationChangelistState->ShelveId))
 	{
-		TArray<FString> Results;
 		TArray<FString> Errors;
-		TArray<FString> Parameters;
-		Parameters.Add(TEXT("delete"));
-		Parameters.Add(FString::Printf(TEXT("sh:%d"), DestinationChangelistState->ShelveId));
-		PlasticSourceControlUtils::RunCommand(TEXT("shelveset"), Parameters, TArray<FString>(), Results, Errors);
+		DeleteShelve(DestinationChangelistState->ShelveId, Errors);
 	}
 	DestinationChangelistState->ShelveId = ShelveId;
 
@@ -1939,10 +1943,7 @@ bool FPlasticDeleteShelveWorker::Execute(FPlasticSourceControlCommand& InCommand
 
 	if (InCommand.bCommandSuccessful)
 	{
-		TArray<FString> Parameters;
-		Parameters.Add(TEXT("delete"));
-		Parameters.Add(FString::Printf(TEXT("sh:%d"), ChangelistState->ShelveId));
-		InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("shelveset"), Parameters, TArray<FString>(), InCommand.InfoMessages, InCommand.ErrorMessages);
+		InCommand.bCommandSuccessful = DeleteShelve(ChangelistState->ShelveId, InCommand.ErrorMessages);
 
 		if (InCommand.bCommandSuccessful)
 		{


### PR DESCRIPTION
Refactor code around shelve creation to fix the cache issue with the Changelist Description formatter like the Shelve Description by mistake.
It could lead to a shelve named with a double prefix "ChangelistXXX: ChangelistXXX: ".

The code is much cleaner, more readable now.