### PR TITLE
Implement deletion of selected files in a shelve

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
@@ -510,6 +510,9 @@ protected:
 
 	/** Changelist to be updated */
 	FPlasticSourceControlChangelist ChangelistToUpdate;
+
+	/** Id of the new shelve (if only a selection of files are deleted from the shelve) */
+	int32 ShelveId = ISourceControlState::INVALID_REVISION;
 };
 
 #endif


### PR DESCRIPTION
This operation is not supported by Plastic SCM, but we can emulate the behavior of removing files of an existing shelve by in fact creating a new shelve with all the previous files minus the selected ones.