### PR TITLE
Fix checkin changelist with blank comment

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -424,6 +424,13 @@ bool FPlasticCheckInWorker::UpdateStates()
 		}
 		else
 		{
+			// Remove references to the changelist (else it later creates a phantom of the old changelist in the cache)
+			for (const FPlasticSourceControlState& NewState : States)
+			{
+				TSharedRef<FPlasticSourceControlState, ESPMode::ThreadSafe> State = GetProvider().GetStateInternal(NewState.GetFilename());
+				State->Changelist.Reset();
+			}
+
 			GetProvider().RemoveChangelistFromCache(InChangelist);
 		}
 	}

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -326,6 +326,7 @@ bool FPlasticCheckInWorker::Execute(FPlasticSourceControlCommand& InCommand)
 
 	check(InCommand.Operation->GetName() == GetName());
 	TSharedRef<FCheckIn, ESPMode::ThreadSafe> Operation = StaticCastSharedRef<FCheckIn>(InCommand.Operation);
+	FText Description = Operation->GetDescription();
 
 	TArray<FString> Files;
 #if ENGINE_MAJOR_VERSION == 5
@@ -333,6 +334,11 @@ bool FPlasticCheckInWorker::Execute(FPlasticSourceControlCommand& InCommand)
 	{
 		TSharedRef<FPlasticSourceControlChangelistState, ESPMode::ThreadSafe> ChangelistState = GetProvider().GetStateInternal(InCommand.Changelist);
 		Files = FileNamesFromFileStates(ChangelistState->Files);
+
+		if (Description.IsEmpty())
+		{
+			Description = ChangelistState->GetDescriptionText();
+		}
 
 		InChangelist = InCommand.Changelist;
 	}
@@ -344,10 +350,10 @@ bool FPlasticCheckInWorker::Execute(FPlasticSourceControlCommand& InCommand)
 
 	if (Files.Num() > 0)
 	{
-		UE_LOG(LogSourceControl, Verbose, TEXT("CheckIn: %d file(s) Description: '%s'"), Files.Num(), *Operation->GetDescription().ToString());
+		UE_LOG(LogSourceControl, Verbose, TEXT("CheckIn: %d file(s) Description: '%s'"), Files.Num(), *Description.ToString());
 
 		// make a temp file to place our commit message in
-		const FScopedTempFile CommitMsgFile(Operation->GetDescription());
+		const FScopedTempFile CommitMsgFile(Description);
 		if (!CommitMsgFile.GetFilename().IsEmpty())
 		{
 			TArray<FString> Parameters;


### PR DESCRIPTION
Fix missing changeset comment when checkin a changelist without making any change to its description.

It's in fact a bug with the UI of the Unreal Editor itself, that trigger a checkin with an empty description!
so we retrieve it directly from the changelist in this specific case.
