### PR TITLE
Add support to diff a file from a shelve

### DIFF
--- a/README.md
+++ b/README.md
@@ -499,6 +499,7 @@ This version here is the development version, so it always contains additional f
 ### Feature Requests
  - Unreal Engine 5.1 full support
    - Uncontrolled Changelists
+ - Shelves on Xlinks sub-repositories
  - Solve a merge conflict on a blueprint (see Known issues below)
  - Mac OS X Support
  - add a menu entry to switch the workspace to Partial

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlChangelistState.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlChangelistState.h
@@ -79,6 +79,7 @@ public:
 	TArray<FSourceControlStateRef> Files;
 
 	int32 ShelveId = ISourceControlState::INVALID_REVISION;
+	FDateTime ShelveDate;
 
 	TArray<FSourceControlStateRef> ShelvedFiles;
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -1850,11 +1850,10 @@ bool FPlasticShelveWorker::UpdateStates()
 
 	// And finally, add the shelved files to the changelist state
 	DestinationChangelistState->ShelvedFiles.Reset(ShelvedFiles.Num());
-	for (FString& ShelvedFile : ShelvedFiles)
+	for (FString ShelvedFile : ShelvedFiles)
 	{
 		TSharedRef<FPlasticSourceControlState, ESPMode::ThreadSafe> FileState = GetProvider().GetStateInternal(ShelvedFile);
-		TSharedRef<FPlasticSourceControlState, ESPMode::ThreadSafe> ShelveState = MakeShared<FPlasticSourceControlState>(MoveTemp(ShelvedFile), FileState->WorkspaceState);
-		DestinationChangelistState->ShelvedFiles.Add(ShelveState);
+		PlasticSourceControlUtils::AddShelvedFileToChangelist(DestinationChangelistState.Get(), MoveTemp(ShelvedFile), FileState->WorkspaceState);
 	}
 
 	return bMovedFiles || ShelvedFiles.Num() > 0;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlRevision.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlRevision.h
@@ -56,6 +56,9 @@ public:
 	/** The revision to display to the user: use the changeset number */
 	FString Revision;
 
+	/** The Shelve ID instead of Changeset / Revision for case of shelved files */
+	int32 ShelveId = ISourceControlState::INVALID_REVISION;
+
 	/** The description of this revision */
 	FString Description;
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -1752,6 +1752,7 @@ void AddShelvedFileToChangelist(FPlasticSourceControlChangelistState& InOutChang
 		SourceControlRevision->Filename = ShelveState->GetFilename();
 		SourceControlRevision->ShelveId = InOutChangelistsState.ShelveId;
 		SourceControlRevision->ChangesetNumber = InOutChangelistsState.ShelveId; // Note: for display in the diff window only
+		SourceControlRevision->Date = InOutChangelistsState.ShelveDate; // Note: not yet used for display as of UE5.1.1
 
 		ShelveState->History.Add(SourceControlRevision);
 	}
@@ -1874,6 +1875,7 @@ static bool ParseShelvesResults(const FXmlFile& InXmlResult, TArray<FPlasticSour
 	static const FString PlasticQuery(TEXT("PLASTICQUERY"));
 	static const FString Shelve(TEXT("SHELVE"));
 	static const FString ShelveId(TEXT("SHELVEID"));
+	static const FString Date(TEXT("DATE"));
 	static const FString Comment(TEXT("COMMENT"));
 
 	const FString& WorkingDirectory = FPlasticSourceControlModule::Get().GetProvider().GetPathToWorkspaceRoot();
@@ -1906,6 +1908,12 @@ static bool ParseShelvesResults(const FXmlFile& InXmlResult, TArray<FPlasticSour
 			if (CommentString.StartsWith(ChangelistPrefix))
 			{
 				ChangelistState.ShelveId = FCString::Atoi(*ShelveIdString);
+
+				if (const FXmlNode* DateNode = ShelveNode->FindChildNode(Date))
+				{
+					const FString& DateIso = DateNode->GetContent();
+					FDateTime::ParseIso8601(*DateIso, ChangelistState.ShelveDate);
+				}
 			}
 		}
 	}

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
@@ -13,6 +13,11 @@ class FPlasticSourceControlCommand;
 class FPlasticSourceControlState;
 struct FSoftwareVersion;
 
+namespace EWorkspaceState
+{
+	enum Type;
+}
+
 namespace PlasticSourceControlUtils
 {
 
@@ -178,6 +183,14 @@ bool RunGetChangelists(TArray<FPlasticSourceControlChangelistState>& OutChangeli
  * @param	OutErrorMessages		Any errors (from StdErr) as an array per-line
  */
 bool RunGetShelves(TArray<FPlasticSourceControlChangelistState>& InOutChangelistsStates, TArray<FString>& OutErrorMessages);
+
+/**
+ * Add a file to the shelve associated with a changelist.
+ * @param	InOutChangelistsState	The changelist to add the file to
+ * @param	InFilename				The file to add to the shelve
+ * @param	InShelveStatus			The status of the file
+ */
+void AddShelvedFileToChangelist(FPlasticSourceControlChangelistState& InOutChangelistsState, FString&& InFilename, EWorkspaceState::Type InShelveStatus);
 
 #endif
 


### PR DESCRIPTION
- Get the content of a shelved file when the revision refers to a ShelveId instead of the ChangesetNumber