### PR TITLE
Also add support for ShouldDeleteNewFiles to the RevertAll operation

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -445,6 +445,8 @@ bool FPlasticCheckInWorker::UpdateStates()
 				// 1- Remove these files from their previous changelist
 				TSharedRef<FPlasticSourceControlChangelistState, ESPMode::ThreadSafe> PreviousChangelist = GetProvider().GetStateInternal(State->Changelist);
 				PreviousChangelist->Files.Remove(State);
+				// 2- And reset the reference to their previous changelist
+				State->Changelist.Reset();
 			}
 		}
 	}
@@ -647,6 +649,8 @@ bool FPlasticRevertWorker::UpdateStates()
 			// 1- Remove these files from their previous changelist
 			TSharedRef<FPlasticSourceControlChangelistState, ESPMode::ThreadSafe> PreviousChangelist = GetProvider().GetStateInternal(State->Changelist);
 			PreviousChangelist->Files.Remove(State);
+			// 2- And reset the reference to their previous changelist
+			State->Changelist.Reset();
 		}
 	}
 #endif
@@ -710,6 +714,8 @@ bool FPlasticRevertUnchangedWorker::UpdateStates()
 				// 1- Remove these files from their previous changelist
 				TSharedRef<FPlasticSourceControlChangelistState, ESPMode::ThreadSafe> PreviousChangelist = GetProvider().GetStateInternal(State->Changelist);
 				PreviousChangelist->Files.Remove(State);
+				// 2- And reset the reference to their previous changelist
+				State->Changelist.Reset();
 			}
 		}
 	}
@@ -802,6 +808,8 @@ bool FPlasticRevertAllWorker::UpdateStates()
 				// 1- Remove these files from their previous changelist
 				TSharedRef<FPlasticSourceControlChangelistState, ESPMode::ThreadSafe> PreviousChangelist = GetProvider().GetStateInternal(State->Changelist);
 				PreviousChangelist->Files.Remove(State);
+				// 2- And reset the reference to their previous changelist
+				State->Changelist.Reset();
 			}
 		}
 	}
@@ -973,6 +981,8 @@ bool FPlasticUpdateStatusWorker::UpdateStates()
 				// 1- Remove these files from their previous changelist
 				TSharedRef<FPlasticSourceControlChangelistState, ESPMode::ThreadSafe> PreviousChangelist = GetProvider().GetStateInternal(State->Changelist);
 				PreviousChangelist->Files.Remove(State);
+				// 2- And reset the reference to their previous changelist
+				State->Changelist.Reset();
 			}
 		}
 	}

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -741,6 +741,13 @@ bool FPlasticRevertAllWorker::Execute(FPlasticSourceControlCommand& InCommand)
 		{
 			if (State.IsModified())
 			{
+#if ENGINE_MAJOR_VERSION == 5
+				if (State.WorkspaceState == EWorkspaceState::Added && Operation->ShouldDeleteNewFiles())
+				{
+					IFileManager::Get().Delete(*State.GetFilename());
+				}
+#endif
+
 				// Add all modified files to the list of files to be updated (reverted and then reloaded)
 				Operation->UpdatedFiles.Add(MoveTemp(State.LocalFilename));
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -581,14 +581,9 @@ bool FPlasticRevertWorker::Execute(FPlasticSourceControlCommand& InCommand)
 	TRACE_CPUPROFILER_EVENT_SCOPE(FPlasticRevertWorker::Execute);
 
 	check(InCommand.Operation->GetName() == GetName());
+	TSharedRef<FRevert, ESPMode::ThreadSafe> Operation = StaticCastSharedRef<FRevert>(InCommand.Operation);
 
 	TArray<FString> Files = GetFilesFromCommand(GetProvider(), InCommand);
-
-#if ENGINE_MAJOR_VERSION == 5
-	TSharedRef<FRevert, ESPMode::ThreadSafe> RevertOperation = StaticCastSharedRef<FRevert>(InCommand.Operation);
-
-	const bool ShouldDeleteNewFiles = RevertOperation->ShouldDeleteNewFiles();
-#endif
 
 	for (int i = 0; i < Files.Num(); i++) // Required for loop on index since we are adding to the Files array as we go
 	{
@@ -612,7 +607,7 @@ bool FPlasticRevertWorker::Execute(FPlasticSourceControlCommand& InCommand)
 		}
 
 #if ENGINE_MAJOR_VERSION == 5
-		if (State->WorkspaceState == EWorkspaceState::Added && ShouldDeleteNewFiles)
+		if (State->WorkspaceState == EWorkspaceState::Added && Operation->ShouldDeleteNewFiles())
 		{
 			IFileManager::Get().Delete(*File);
 		}

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
@@ -54,7 +54,7 @@ public:
 /**
  * Internal operation used to revert checked-out files
 */
-class FPlasticRevertAll final : public ISourceControlOperation
+class FPlasticRevertAll final : public FRevert
 {
 public:
 	// ISourceControlOperation interface


### PR DESCRIPTION
Unreal Engine 5 added a Source Control project settings to let users decide if they want to delete newly added files when calling Revert (true by default).

The first PR https://github.com/SRombauts/UEPlasticPlugin/pull/124 covered the support for that parameter for the regular "Revert" operation, but we didn't implemented it for our custom global "RevertAll" operation!

This new PR adresses that, while also refactoring a bit the code around so there is less duplicates and less #ifdef