### PR TITLE
Add support for Unreal 5 "soft revert" to undockeckout without reverting the file content

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -648,7 +648,12 @@ bool FPlasticRevertWorker::Execute(FPlasticSourceControlCommand& InCommand)
 		// Detect special case for a partial checkout (CS:-1 in Gluon mode)!
 		if (-1 != InCommand.ChangesetNumber)
 		{
-			InCommand.bCommandSuccessful &= PlasticSourceControlUtils::RunCommand(TEXT("undocheckout"), TArray<FString>(), CheckedOutFiles, InCommand.InfoMessages, InCommand.ErrorMessages);
+			TArray<FString> Parameters;
+			if (Operation->IsSoftRevert())
+			{
+				Parameters.Add(TEXT("--keepchanges"));
+			}
+			InCommand.bCommandSuccessful &= PlasticSourceControlUtils::RunCommand(TEXT("undocheckout"), Parameters, CheckedOutFiles, InCommand.InfoMessages, InCommand.ErrorMessages);
 		}
 		else
 		{

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
@@ -20,14 +20,14 @@ namespace EWorkspaceState
 		Unknown,
 		Ignored,
 		Controlled, // called "Pristine" in Perforce, "Unchanged" in Git, "Clean" in SVN
-		CheckedOut,
+		CheckedOut, // Checked-out, without telling if Changed or not
 		Added,
 		Moved, // Renamed
 		Copied,
 		Replaced, // Replaced / Merged
 		Deleted,
 		LocallyDeleted, // Missing
-		Changed, // Modified but not CheckedOut
+		Changed, // Locally Changed but not CheckedOut
 		Conflicted,
 		Private, // "Not Controlled"/"Not In Depot"/"Untracked"
 	};

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlVersions.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlVersions.h
@@ -29,4 +29,8 @@ namespace PlasticSourceControlVersions
 	// https://www.plasticscm.com/download/releasenotes/11.0.16.7608
 	static const FSoftwareVersion NewHistoryLimit(TEXT("11.0.16.7608"));
 
+	// 11.0.16.7608 add support for undocheckout --keepchanges. It allows undo checkout and preserve all local changes.
+	// https://www.plasticscm.com/download/releasenotes/11.0.16.7665
+	static const FSoftwareVersion UndoCheckoutKeepChanges(TEXT("11.0.16.7665"));
+
 } // namespace PlasticSourceControlVersions


### PR DESCRIPTION
Unreal Engine 5 support a "soft revert" that just uncheckout to unlock but don't change content.

Plastic SCM min version supporting this new flag: https://www.plasticscm.com/download/releasenotes/11.0.16.7665