### PR TITLE
Re-enable implementation of UsesFileRevisions() 

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
@@ -476,6 +476,11 @@ Remove / disable 'Check-in' context menu item in Content Explorer and Scene Outl
 	return true;
 }
 
+bool FPlasticSourceControlProvider::UsesSnapshots() const
+{
+	return false;
+}
+
 bool FPlasticSourceControlProvider::AllowsDiffAgainstDepot() const
 {
 	return true;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
@@ -451,29 +451,19 @@ bool FPlasticSourceControlProvider::UsesCheckout() const
 
 bool FPlasticSourceControlProvider::UsesFileRevisions() const
 {
-	/* TODO: this API is broken, it is preventing the user to use the source control context menu, as well as selecting what files to submit
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
 
-	// Only a partial workspace can sync files individually like Perforce, a regular workspace needs to update completely
+	// Only a Partial/Gluon workspace can sync/update files individually, operating on revisions (can use the context menu)
+	// while a regular workspace can only update all the files as a whole, operating at the changeset level (requires the global menu)
 	return IsPartialWorkspace();
-	
-	I believe that the logic is in fact flawed from what we would expect!
-	IMO Context & selected check-in should be forbidden if the provider use changelists, not the reverse!
-	(and using changelists could become a setting)
 
-	NOTE: the bug was introduced in UE5.1 by:
-
-Commit 5803c744 by marco anastasi, 10/04/2022 02:36 AM
-
-Remove / disable 'Check-in' context menu item in Content Explorer and Scene Outliner for Source Control providers that do not use changelists
-
-#rb stuart.hill, wouter.burgers
-#preflight 633ac338c37844870ac69f67
-
-[CL 22322177 by marco anastasi in ue5-main branch]
-
-	*/
-	
+#else
+	// This API introduced in UE5.1 was broken (preventing the user to use the source control context menu for checkin,
+	// as well as selecting what files to submit in the global Submit Content window)
+	// but is now fixed in UE5.2 through the use of the new following UsesSnapshots() API
 	return true;
+
+#endif
 }
 
 bool FPlasticSourceControlProvider::UsesSnapshots() const

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.h
@@ -47,7 +47,7 @@ public:
 #elif ENGINE_MAJOR_VERSION == 5
 	virtual ECommandResult::Type Execute(const FSourceControlOperationRef& InOperation, FSourceControlChangelistPtr InChangelist, const TArray<FString>& InFiles, EConcurrency::Type InConcurrency = EConcurrency::Synchronous, const FSourceControlOperationComplete& InOperationCompleteDelegate = FSourceControlOperationComplete() ) override;
 #endif
-	virtual bool CanExecuteOperation( const FSourceControlOperationRef& InOperation ) const; /* override	NOTE: added in UE5.2 */
+	virtual bool CanExecuteOperation( const FSourceControlOperationRef& InOperation ) const; /* override	NOTE: added in UE5.3 */
 	virtual bool CanCancelOperation(const FSourceControlOperationRef& InOperation) const override;
 	virtual void CancelOperation(const FSourceControlOperationRef& InOperation) override;
 	virtual bool UsesLocalReadOnlyState() const override;
@@ -55,6 +55,7 @@ public:
 	virtual bool UsesUncontrolledChangelists() const; /* override	NOTE: added in UE5.2 */
 	virtual bool UsesCheckout() const override;
 	virtual bool UsesFileRevisions() const; /* override				NOTE: added in UE5.1 */
+	virtual bool UsesSnapshots() const; /* override					NOTE: added in UE5.2 */
 	virtual bool AllowsDiffAgainstDepot() const; /* override		NOTE: added in UE5.2 */
 	virtual TOptional<bool> IsAtLatestRevision() const; /* override	NOTE: added in UE5.1 */
 	virtual TOptional<int> GetNumLocalChanges() const; /* override	NOTE: added in UE5.1 */


### PR DESCRIPTION
based on IsPartialWorkspace() for UE5.2 and forward only, now that Epic Games has fix the issue we reported that prevented users to checkin from the context menu, or the select files to checkin from the global Submit Content entry:
https://github.com/EpicGames/UnrealEngine/commit/4a957c39