### PR TITLE
Detect asset checked-out but unchanged

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -1311,7 +1311,7 @@ bool FPlasticGetPendingChangelistsWorker::UpdateStates()
 		ChangelistState->TimeStamp = Now;
 		bUpdated = true;
 
-		// Update files states for files in the changelist
+		// Update files in the changelist
 		bool bUpdateFilesStates = (OutCLFilesStates.Num() == OutChangelistsStates.Num());
 		if (bUpdateFilesStates)
 		{

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -747,7 +747,7 @@ bool FPlasticRevertUnchangedWorker::UpdateStates()
 	// Update affected changelists if any
 	for (const FPlasticSourceControlState& NewState : States)
 	{
-		if (!NewState.CanRevert()) // IsModified() || CheckedOutUnchanged
+		if (!NewState.IsCheckedOutImplementation())
 		{
 			TSharedRef<FPlasticSourceControlState, ESPMode::ThreadSafe> State = GetProvider().GetStateInternal(NewState.GetFilename());
 			if (State->Changelist.IsInitialized())
@@ -786,7 +786,7 @@ bool FPlasticRevertAllWorker::Execute(FPlasticSourceControlCommand& InCommand)
 
 		for (auto& State : TempStates)
 		{
-			if (State.CanRevert()) // IsModified() || CheckedOutUnchanged
+			if (State.CanRevert())
 			{
 #if ENGINE_MAJOR_VERSION == 5
 				if (State.WorkspaceState == EWorkspaceState::Added && Operation->ShouldDeleteNewFiles())
@@ -846,7 +846,7 @@ bool FPlasticRevertAllWorker::UpdateStates()
 	for (const FPlasticSourceControlState& NewState : States)
 	{
 		// TODO: also detect files that were added and are now private! Should be removed as well from their changelist
-		if (!NewState.CanRevert()) // IsModified() || CheckedOutUnchanged
+		if (!NewState.IsCheckedOutImplementation())
 		{
 			TSharedRef<FPlasticSourceControlState, ESPMode::ThreadSafe> State = GetProvider().GetStateInternal(NewState.GetFilename());
 			if (State->Changelist.IsInitialized())
@@ -1008,7 +1008,7 @@ bool FPlasticUpdateStatusWorker::UpdateStates()
 	// Update affected changelists if any (in case of a file reverted outside of the Unreal Editor)
 	for (const FPlasticSourceControlState& NewState : States)
 	{
-		if (!NewState.CanRevert()) // IsModified() || CheckedOutUnchanged
+		if (!NewState.IsCheckedOutImplementation())
 		{
 			TSharedRef<FPlasticSourceControlState, ESPMode::ThreadSafe> State = GetProvider().GetStateInternal(NewState.GetFilename());
 			if (State->Changelist.IsInitialized())

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -747,7 +747,7 @@ bool FPlasticRevertUnchangedWorker::UpdateStates()
 	// Update affected changelists if any
 	for (const FPlasticSourceControlState& NewState : States)
 	{
-		if (!NewState.IsModified())
+		if (!NewState.CanRevert()) // IsModified() || CheckedOutUnchanged
 		{
 			TSharedRef<FPlasticSourceControlState, ESPMode::ThreadSafe> State = GetProvider().GetStateInternal(NewState.GetFilename());
 			if (State->Changelist.IsInitialized())
@@ -786,7 +786,7 @@ bool FPlasticRevertAllWorker::Execute(FPlasticSourceControlCommand& InCommand)
 
 		for (auto& State : TempStates)
 		{
-			if (State.IsModified())
+			if (State.CanRevert()) // IsModified() || CheckedOutUnchanged
 			{
 #if ENGINE_MAJOR_VERSION == 5
 				if (State.WorkspaceState == EWorkspaceState::Added && Operation->ShouldDeleteNewFiles())
@@ -846,7 +846,7 @@ bool FPlasticRevertAllWorker::UpdateStates()
 	for (const FPlasticSourceControlState& NewState : States)
 	{
 		// TODO: also detect files that were added and are now private! Should be removed as well from their changelist
-		if (!NewState.IsModified())
+		if (!NewState.CanRevert()) // IsModified() || CheckedOutUnchanged
 		{
 			TSharedRef<FPlasticSourceControlState, ESPMode::ThreadSafe> State = GetProvider().GetStateInternal(NewState.GetFilename());
 			if (State->Changelist.IsInitialized())
@@ -1008,7 +1008,7 @@ bool FPlasticUpdateStatusWorker::UpdateStates()
 	// Update affected changelists if any (in case of a file reverted outside of the Unreal Editor)
 	for (const FPlasticSourceControlState& NewState : States)
 	{
-		if (!NewState.IsModified())
+		if (!NewState.CanRevert()) // IsModified() || CheckedOutUnchanged
 		{
 			TSharedRef<FPlasticSourceControlState, ESPMode::ThreadSafe> State = GetProvider().GetStateInternal(NewState.GetFilename());
 			if (State->Changelist.IsInitialized())

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -198,15 +198,8 @@ static void UpdateChangelistState(FPlasticSourceControlProvider& SCCProvider, co
 
 		for (const FPlasticSourceControlState& InState : InStates)
 		{
-			// cm cannot yet handle local modifications in changelists, only the GUI can
-			if (   InState.WorkspaceState != EWorkspaceState::CheckedOutChanged
-				&& InState.WorkspaceState != EWorkspaceState::Added
-				&& InState.WorkspaceState != EWorkspaceState::Deleted
-				&& InState.WorkspaceState != EWorkspaceState::Copied
-				&& InState.WorkspaceState != EWorkspaceState::Moved
-				&& InState.WorkspaceState != EWorkspaceState::Conflicted	// In source control, waiting for merged
-				&& InState.WorkspaceState != EWorkspaceState::Replaced		// In source control, merged, waiting for checkin to conclude the merge
-				)
+			// Note: cannot use IsModified() because cm cannot yet handle local modifications in changelists, only the GUI can
+			if (!InState.IsCheckedOutImplementation())
 			{
 				continue;
 			}

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -199,7 +199,7 @@ static void UpdateChangelistState(FPlasticSourceControlProvider& SCCProvider, co
 		for (const FPlasticSourceControlState& InState : InStates)
 		{
 			// cm cannot yet handle local modifications in changelists, only the GUI can
-			if (   InState.WorkspaceState != EWorkspaceState::CheckedOut
+			if (   InState.WorkspaceState != EWorkspaceState::CheckedOutChanged
 				&& InState.WorkspaceState != EWorkspaceState::Added
 				&& InState.WorkspaceState != EWorkspaceState::Deleted
 				&& InState.WorkspaceState != EWorkspaceState::Copied

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.h
@@ -22,8 +22,9 @@ DECLARE_DELEGATE_RetVal_OneParam(FPlasticSourceControlWorkerRef, FGetPlasticSour
 class FPlasticSourceControlProvider : public ISourceControlProvider
 {
 public:
-	/** Constructor */
+	/** Constructor & destructor */
 	FPlasticSourceControlProvider();
+	~FPlasticSourceControlProvider();
 
 	/* ISourceControlProvider implementation */
 	virtual void Init(bool bForceConnection = true) override;
@@ -226,6 +227,9 @@ private:
 
 	/** Update workspace status on Connect and UpdateStatus operations */
 	void UpdateWorkspaceStatus(const class FPlasticSourceControlCommand& InCommand);
+
+	/** Called after a package has been saved to disk */
+	void HandlePackageSaved(const FString& PackageFilename, UPackage* Package, FObjectPostSaveContext ObjectSaveContext);
 
 	/** Version of the Unity Version Control executable used */
 	FSoftwareVersion PlasticScmVersion;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.h
@@ -228,8 +228,8 @@ private:
 	/** Update workspace status on Connect and UpdateStatus operations */
 	void UpdateWorkspaceStatus(const class FPlasticSourceControlCommand& InCommand);
 
-	/** Called after a package has been saved to disk */
-	void HandlePackageSaved(const FString& PackageFilename, UPackage* Package, FObjectPostSaveContext ObjectSaveContext);
+	/** Called after a package has been saved to disk, to update the source control cache */
+	void HandlePackageSaved(const FString& InPackageFilename, UPackage* InPackage, FObjectPostSaveContext InObjectSaveContext);
 
 	/** Version of the Unity Version Control executable used */
 	FSoftwareVersion PlasticScmVersion;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
@@ -642,13 +642,14 @@ bool FPlasticSourceControlState::IsUnknown() const
 
 bool FPlasticSourceControlState::IsModified() const
 {
-	// Warning: for a clean "checkin" (commit) checked-out files unmodified should be removed from the changeset (the index)
+	// Warning: for a clean "checkin" (commit) checked-out files unmodified should be removed from the changeset (Perforce)
 	//
 	// Thus, before checkin UE4 Editor call RevertUnchangedFiles() in PromptForCheckin() and CheckinFiles().
 	//
 	// So here we must take care to enumerate all states that need to be committed, all other will be discarded:
 	//  - Unknown
 	//  - Controlled (Unchanged)
+	//  - CheckedOutUnchanged
 	//  - Private (Not Controlled)
 	//  - Ignored
 	const bool bIsModified =   WorkspaceState == EWorkspaceState::CheckedOutChanged
@@ -683,7 +684,7 @@ bool FPlasticSourceControlState::IsConflicted() const
 
 bool FPlasticSourceControlState::CanRevert() const
 {
-	return IsModified();
+	return IsModified() || WorkspaceState == EWorkspaceState::CheckedOutUnchanged;
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
@@ -467,8 +467,7 @@ bool FPlasticSourceControlState::CanCheckout() const
 	}
 
 	const bool bCanCheckout  =    (WorkspaceState == EWorkspaceState::Controlled	// In source control, Unmodified
-								|| WorkspaceState == EWorkspaceState::Changed		// In source control, but not checked-out
-								|| WorkspaceState == EWorkspaceState::Replaced)		// In source control, merged, waiting for checkin to conclude the merge
+								|| WorkspaceState == EWorkspaceState::Changed)		// In source control, but not checked-out
 								&& !IsCheckedOutOther()	// Is not already checked-out elsewhere
 								&& IsCurrent();			// Is up to date (at the revision of the repo)
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
@@ -505,6 +505,20 @@ bool FPlasticSourceControlState::IsCheckedOut() const
 	}
 }
 
+bool FPlasticSourceControlState::IsCheckedOutImplementation() const
+{
+	const bool bIsCheckedOut = WorkspaceState == EWorkspaceState::CheckedOutChanged
+							|| WorkspaceState == EWorkspaceState::CheckedOutUnchanged
+							|| WorkspaceState == EWorkspaceState::Added
+							|| WorkspaceState == EWorkspaceState::Deleted
+							|| WorkspaceState == EWorkspaceState::Copied
+							|| WorkspaceState == EWorkspaceState::Moved
+							|| WorkspaceState == EWorkspaceState::Conflicted	// In source control, waiting for merge
+							|| WorkspaceState == EWorkspaceState::Replaced;		// In source control, merged, waiting for checkin to conclude the merge
+
+	return bIsCheckedOut;
+}
+
 bool FPlasticSourceControlState::IsCheckedOutOther(FString* Who) const
 {
 	if (Who != NULL)

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
@@ -160,7 +160,7 @@ FName FPlasticSourceControlState::GetSmallIconName() const
 	{
 		return FName("Perforce.NotAtHeadRevision_Small");
 	}
-	else if (WorkspaceState != EWorkspaceState::CheckedOutChanged && (WorkspaceState != EWorkspaceState::CheckedOutUnchanged)
+	else if (WorkspaceState != EWorkspaceState::CheckedOutChanged && WorkspaceState != EWorkspaceState::CheckedOutUnchanged)
 	{
 		if (IsCheckedOutOther())
 		{

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
@@ -17,7 +17,7 @@ const TCHAR* FPlasticSourceControlState::ToString() const
 		case EWorkspaceState::Unknown: WorkspaceStateStr = TEXT("Unknown"); break;
 		case EWorkspaceState::Ignored: WorkspaceStateStr = TEXT("Ignored"); break;
 		case EWorkspaceState::Controlled: WorkspaceStateStr = TEXT("Controlled"); break;
-		case EWorkspaceState::CheckedOut: WorkspaceStateStr = TEXT("CheckedOut"); break;
+		case EWorkspaceState::CheckedOutChanged: WorkspaceStateStr = TEXT("CheckedOutChanged"); break;
 		case EWorkspaceState::Added: WorkspaceStateStr = TEXT("Added"); break;
 		case EWorkspaceState::Moved: WorkspaceStateStr = TEXT("Moved"); break;
 		case EWorkspaceState::Copied: WorkspaceStateStr = TEXT("Copied"); break;
@@ -106,7 +106,7 @@ FName FPlasticSourceControlState::GetIconName() const
 	{
 		return FName("Perforce.NotAtHeadRevision");
 	}
-	else if (WorkspaceState != EWorkspaceState::CheckedOut)
+	else if (WorkspaceState != EWorkspaceState::CheckedOutChanged)
 	{
 		if (IsCheckedOutOther())
 		{
@@ -120,7 +120,7 @@ FName FPlasticSourceControlState::GetIconName() const
 
 	switch (WorkspaceState)
 	{
-	case EWorkspaceState::CheckedOut:
+	case EWorkspaceState::CheckedOutChanged:
 	case EWorkspaceState::Replaced: // Merged (waiting for checkin)
 		return FName("Perforce.CheckedOut");
 	case EWorkspaceState::Added:
@@ -158,7 +158,7 @@ FName FPlasticSourceControlState::GetSmallIconName() const
 	{
 		return FName("Perforce.NotAtHeadRevision_Small");
 	}
-	else if (WorkspaceState != EWorkspaceState::CheckedOut)
+	else if (WorkspaceState != EWorkspaceState::CheckedOutChanged)
 	{
 		if (IsCheckedOutOther())
 		{
@@ -172,7 +172,7 @@ FName FPlasticSourceControlState::GetSmallIconName() const
 
 	switch (WorkspaceState)
 	{
-	case EWorkspaceState::CheckedOut:
+	case EWorkspaceState::CheckedOutChanged:
 	case EWorkspaceState::Replaced: // Merged (waiting for checkin)
 		return FName("Perforce.CheckedOut_Small");
 	case EWorkspaceState::Added:
@@ -212,7 +212,7 @@ FSlateIcon FPlasticSourceControlState::GetIcon() const
 	{
 		return FSlateIcon(FAppStyle::GetAppStyleSetName(), "Perforce.NotAtHeadRevision");
 	}
-	else if (WorkspaceState != EWorkspaceState::CheckedOut && WorkspaceState != EWorkspaceState::Conflicted)
+	else if (WorkspaceState != EWorkspaceState::CheckedOutChanged && WorkspaceState != EWorkspaceState::Conflicted)
 	{
 		if (IsCheckedOutOther())
 		{
@@ -228,7 +228,7 @@ FSlateIcon FPlasticSourceControlState::GetIcon() const
 
 	switch (WorkspaceState)
 	{
-	case EWorkspaceState::CheckedOut:
+	case EWorkspaceState::CheckedOutChanged:
 	case EWorkspaceState::Replaced: // Merged (waiting for check-in)
 		return FSlateIcon(FAppStyle::GetAppStyleSetName(), "Plastic.CheckedOut");
 	case EWorkspaceState::Changed: // Changed but unchecked-out file custom color icon
@@ -258,7 +258,7 @@ FSlateIcon FPlasticSourceControlState::GetIcon() const
 
 	switch (WorkspaceState)
 	{
-	case EWorkspaceState::CheckedOut:
+	case EWorkspaceState::CheckedOutChanged:
 	case EWorkspaceState::Replaced: // Merged (waiting for checkin)
 		return FSlateIcon(FAppStyle::GetAppStyleSetName(), "Perforce.CheckedOut");
 	case EWorkspaceState::Added:
@@ -303,7 +303,7 @@ FText FPlasticSourceControlState::GetDisplayName() const
 		return FText::Format(LOCTEXT("NotCurrent", "Not at the head revision CS:{0} {1} (local revision is CS:{2})"),
 			FText::AsNumber(DepotRevisionChangeset), FText::FromString(HeadUserName), FText::AsNumber(LocalRevisionChangeset, &NoCommas));
 	}
-	else if (WorkspaceState != EWorkspaceState::CheckedOut && WorkspaceState != EWorkspaceState::Conflicted)
+	else if (WorkspaceState != EWorkspaceState::CheckedOutChanged && WorkspaceState != EWorkspaceState::Conflicted)
 	{
 		if (IsCheckedOutOther())
 		{
@@ -324,8 +324,8 @@ FText FPlasticSourceControlState::GetDisplayName() const
 		return LOCTEXT("Ignored", "Ignored");
 	case EWorkspaceState::Controlled:
 		return LOCTEXT("Controlled", "Controlled");
-	case EWorkspaceState::CheckedOut:
-		return LOCTEXT("CheckedOut", "Checked-out");
+	case EWorkspaceState::CheckedOutChanged:
+		return LOCTEXT("CheckedOutChanged", "Checked-out (Changed)");
 	case EWorkspaceState::Added:
 		return LOCTEXT("Added", "Added");
 	case EWorkspaceState::Moved:
@@ -362,7 +362,7 @@ FText FPlasticSourceControlState::GetDisplayTooltip() const
 		return FText::Format(LOCTEXT("NotCurrent_Tooltip", "Not at the head revision CS:{0} {1} (local revision is CS:{2})"),
 			FText::AsNumber(DepotRevisionChangeset), FText::FromString(HeadUserName), FText::AsNumber(LocalRevisionChangeset, &NoCommas));
 	}
-	else if (WorkspaceState != EWorkspaceState::CheckedOut && WorkspaceState != EWorkspaceState::Conflicted)
+	else if (WorkspaceState != EWorkspaceState::CheckedOutChanged && WorkspaceState != EWorkspaceState::Conflicted)
 	{
 		if (IsCheckedOutOther())
 		{
@@ -383,8 +383,8 @@ FText FPlasticSourceControlState::GetDisplayTooltip() const
 		return LOCTEXT("Ignored_Tooltip", "Ignored");
 	case EWorkspaceState::Controlled:
 		return FText();
-	case EWorkspaceState::CheckedOut:
-		return LOCTEXT("CheckedOut_Tooltip", "Checked-out");
+	case EWorkspaceState::CheckedOutChanged:
+		return LOCTEXT("CheckedOut_Tooltip", "Checked-out (Changed)");
 	case EWorkspaceState::Added:
 		return LOCTEXT("Added_Tooltip", "Added");
 	case EWorkspaceState::Moved:
@@ -438,7 +438,7 @@ bool FPlasticSourceControlState::CanCheckIn() const
 							|| WorkspaceState == EWorkspaceState::Moved
 							|| WorkspaceState == EWorkspaceState::Copied
 							|| WorkspaceState == EWorkspaceState::Replaced
-							|| WorkspaceState == EWorkspaceState::CheckedOut)
+							|| WorkspaceState == EWorkspaceState::CheckedOutChanged)
 							&& !IsCheckedOutOther()	// Is not already checked-out elsewhere
 							&& IsCurrent();			// Is up to date (at the revision of the repo)
 
@@ -473,7 +473,7 @@ bool FPlasticSourceControlState::CanCheckout() const
 
 bool FPlasticSourceControlState::IsCheckedOut() const
 {
-	const bool bIsCheckedOut = WorkspaceState == EWorkspaceState::CheckedOut
+	const bool bIsCheckedOut = WorkspaceState == EWorkspaceState::CheckedOutChanged
 							|| WorkspaceState == EWorkspaceState::Moved
 							|| WorkspaceState == EWorkspaceState::Conflicted	// In source control, waiting for merged
 							|| WorkspaceState == EWorkspaceState::Replaced		// In source control, merged, waiting for checkin to conclude the merge
@@ -504,7 +504,7 @@ bool FPlasticSourceControlState::IsCheckedOutOther(FString* Who) const
 
 	// If the asset is Locked but not CheckedOut locally, it means it is locked somewhere else
 	const bool bIsLocked = !LockedBy.IsEmpty();
-	const bool bIsCheckedOut = WorkspaceState == EWorkspaceState::CheckedOut
+	const bool bIsCheckedOut = WorkspaceState == EWorkspaceState::CheckedOutChanged
 							|| WorkspaceState == EWorkspaceState::Added
 							|| WorkspaceState == EWorkspaceState::Moved
 							|| WorkspaceState == EWorkspaceState::Conflicted	// In source control, waiting for merged
@@ -600,7 +600,7 @@ bool FPlasticSourceControlState::IsIgnored() const
 
 bool FPlasticSourceControlState::CanEdit() const
 {
-	const bool bCanEdit =  WorkspaceState == EWorkspaceState::CheckedOut
+	const bool bCanEdit =  WorkspaceState == EWorkspaceState::CheckedOutChanged
 						|| WorkspaceState == EWorkspaceState::Added
 						|| WorkspaceState == EWorkspaceState::Moved
 						|| WorkspaceState == EWorkspaceState::Copied
@@ -632,7 +632,7 @@ bool FPlasticSourceControlState::IsModified() const
 	//  - Controlled (Unchanged)
 	//  - Private (Not Controlled)
 	//  - Ignored
-	const bool bIsModified =   WorkspaceState == EWorkspaceState::CheckedOut
+	const bool bIsModified =   WorkspaceState == EWorkspaceState::CheckedOutChanged
 							|| WorkspaceState == EWorkspaceState::Added
 							|| WorkspaceState == EWorkspaceState::Moved
 							|| WorkspaceState == EWorkspaceState::Copied

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
@@ -18,6 +18,7 @@ const TCHAR* FPlasticSourceControlState::ToString() const
 		case EWorkspaceState::Ignored: WorkspaceStateStr = TEXT("Ignored"); break;
 		case EWorkspaceState::Controlled: WorkspaceStateStr = TEXT("Controlled"); break;
 		case EWorkspaceState::CheckedOutChanged: WorkspaceStateStr = TEXT("CheckedOutChanged"); break;
+		case EWorkspaceState::CheckedOutUnchanged: WorkspaceStateStr = TEXT("CheckedOutUnchanged"); break;
 		case EWorkspaceState::Added: WorkspaceStateStr = TEXT("Added"); break;
 		case EWorkspaceState::Moved: WorkspaceStateStr = TEXT("Moved"); break;
 		case EWorkspaceState::Copied: WorkspaceStateStr = TEXT("Copied"); break;
@@ -106,7 +107,7 @@ FName FPlasticSourceControlState::GetIconName() const
 	{
 		return FName("Perforce.NotAtHeadRevision");
 	}
-	else if (WorkspaceState != EWorkspaceState::CheckedOutChanged)
+	else if (WorkspaceState != EWorkspaceState::CheckedOutChanged && WorkspaceState != EWorkspaceState::CheckedOutUnchanged)
 	{
 		if (IsCheckedOutOther())
 		{
@@ -121,6 +122,7 @@ FName FPlasticSourceControlState::GetIconName() const
 	switch (WorkspaceState)
 	{
 	case EWorkspaceState::CheckedOutChanged:
+	case EWorkspaceState::CheckedOutUnchanged:
 	case EWorkspaceState::Replaced: // Merged (waiting for checkin)
 		return FName("Perforce.CheckedOut");
 	case EWorkspaceState::Added:
@@ -158,7 +160,7 @@ FName FPlasticSourceControlState::GetSmallIconName() const
 	{
 		return FName("Perforce.NotAtHeadRevision_Small");
 	}
-	else if (WorkspaceState != EWorkspaceState::CheckedOutChanged)
+	else if (WorkspaceState != EWorkspaceState::CheckedOutChanged && (WorkspaceState != EWorkspaceState::CheckedOutUnchanged)
 	{
 		if (IsCheckedOutOther())
 		{
@@ -173,6 +175,7 @@ FName FPlasticSourceControlState::GetSmallIconName() const
 	switch (WorkspaceState)
 	{
 	case EWorkspaceState::CheckedOutChanged:
+	case EWorkspaceState::CheckedOutUnchanged:
 	case EWorkspaceState::Replaced: // Merged (waiting for checkin)
 		return FName("Perforce.CheckedOut_Small");
 	case EWorkspaceState::Added:
@@ -212,7 +215,7 @@ FSlateIcon FPlasticSourceControlState::GetIcon() const
 	{
 		return FSlateIcon(FAppStyle::GetAppStyleSetName(), "Perforce.NotAtHeadRevision");
 	}
-	else if (WorkspaceState != EWorkspaceState::CheckedOutChanged && WorkspaceState != EWorkspaceState::Conflicted)
+	else if (WorkspaceState != EWorkspaceState::CheckedOutChanged && WorkspaceState != EWorkspaceState::CheckedOutUnchanged && WorkspaceState != EWorkspaceState::Conflicted)
 	{
 		if (IsCheckedOutOther())
 		{
@@ -229,6 +232,7 @@ FSlateIcon FPlasticSourceControlState::GetIcon() const
 	switch (WorkspaceState)
 	{
 	case EWorkspaceState::CheckedOutChanged:
+	case EWorkspaceState::CheckedOutUnchanged:
 	case EWorkspaceState::Replaced: // Merged (waiting for check-in)
 		return FSlateIcon(FAppStyle::GetAppStyleSetName(), "Plastic.CheckedOut");
 	case EWorkspaceState::Changed: // Changed but unchecked-out file custom color icon
@@ -259,6 +263,7 @@ FSlateIcon FPlasticSourceControlState::GetIcon() const
 	switch (WorkspaceState)
 	{
 	case EWorkspaceState::CheckedOutChanged:
+	case EWorkspaceState::CheckedOutUnchanged:
 	case EWorkspaceState::Replaced: // Merged (waiting for checkin)
 		return FSlateIcon(FAppStyle::GetAppStyleSetName(), "Perforce.CheckedOut");
 	case EWorkspaceState::Added:
@@ -303,7 +308,7 @@ FText FPlasticSourceControlState::GetDisplayName() const
 		return FText::Format(LOCTEXT("NotCurrent", "Not at the head revision CS:{0} {1} (local revision is CS:{2})"),
 			FText::AsNumber(DepotRevisionChangeset), FText::FromString(HeadUserName), FText::AsNumber(LocalRevisionChangeset, &NoCommas));
 	}
-	else if (WorkspaceState != EWorkspaceState::CheckedOutChanged && WorkspaceState != EWorkspaceState::Conflicted)
+	else if (WorkspaceState != EWorkspaceState::CheckedOutChanged && WorkspaceState != EWorkspaceState::CheckedOutUnchanged && WorkspaceState != EWorkspaceState::Conflicted)
 	{
 		if (IsCheckedOutOther())
 		{
@@ -326,6 +331,8 @@ FText FPlasticSourceControlState::GetDisplayName() const
 		return LOCTEXT("Controlled", "Controlled");
 	case EWorkspaceState::CheckedOutChanged:
 		return LOCTEXT("CheckedOutChanged", "Checked-out (Changed)");
+	case EWorkspaceState::CheckedOutUnchanged:
+		return LOCTEXT("CheckedOutUnchanged", "Checked-out (Unchanged)");
 	case EWorkspaceState::Added:
 		return LOCTEXT("Added", "Added");
 	case EWorkspaceState::Moved:
@@ -362,7 +369,7 @@ FText FPlasticSourceControlState::GetDisplayTooltip() const
 		return FText::Format(LOCTEXT("NotCurrent_Tooltip", "Not at the head revision CS:{0} {1} (local revision is CS:{2})"),
 			FText::AsNumber(DepotRevisionChangeset), FText::FromString(HeadUserName), FText::AsNumber(LocalRevisionChangeset, &NoCommas));
 	}
-	else if (WorkspaceState != EWorkspaceState::CheckedOutChanged && WorkspaceState != EWorkspaceState::Conflicted)
+	else if (WorkspaceState != EWorkspaceState::CheckedOutChanged && WorkspaceState != EWorkspaceState::CheckedOutUnchanged && WorkspaceState != EWorkspaceState::Conflicted)
 	{
 		if (IsCheckedOutOther())
 		{
@@ -385,6 +392,8 @@ FText FPlasticSourceControlState::GetDisplayTooltip() const
 		return FText();
 	case EWorkspaceState::CheckedOutChanged:
 		return LOCTEXT("CheckedOut_Tooltip", "Checked-out (Changed)");
+	case EWorkspaceState::CheckedOutUnchanged:
+		return LOCTEXT("CheckedOut_Tooltip", "Checked-out (Unchanged)");
 	case EWorkspaceState::Added:
 		return LOCTEXT("Added_Tooltip", "Added");
 	case EWorkspaceState::Moved:
@@ -474,6 +483,7 @@ bool FPlasticSourceControlState::CanCheckout() const
 bool FPlasticSourceControlState::IsCheckedOut() const
 {
 	const bool bIsCheckedOut = WorkspaceState == EWorkspaceState::CheckedOutChanged
+							|| WorkspaceState == EWorkspaceState::CheckedOutUnchanged
 							|| WorkspaceState == EWorkspaceState::Moved
 							|| WorkspaceState == EWorkspaceState::Conflicted	// In source control, waiting for merged
 							|| WorkspaceState == EWorkspaceState::Replaced		// In source control, merged, waiting for checkin to conclude the merge
@@ -505,6 +515,7 @@ bool FPlasticSourceControlState::IsCheckedOutOther(FString* Who) const
 	// If the asset is Locked but not CheckedOut locally, it means it is locked somewhere else
 	const bool bIsLocked = !LockedBy.IsEmpty();
 	const bool bIsCheckedOut = WorkspaceState == EWorkspaceState::CheckedOutChanged
+							|| WorkspaceState == EWorkspaceState::CheckedOutUnchanged
 							|| WorkspaceState == EWorkspaceState::Added
 							|| WorkspaceState == EWorkspaceState::Moved
 							|| WorkspaceState == EWorkspaceState::Conflicted	// In source control, waiting for merged
@@ -601,6 +612,7 @@ bool FPlasticSourceControlState::IsIgnored() const
 bool FPlasticSourceControlState::CanEdit() const
 {
 	const bool bCanEdit =  WorkspaceState == EWorkspaceState::CheckedOutChanged
+						|| WorkspaceState == EWorkspaceState::CheckedOutUnchanged
 						|| WorkspaceState == EWorkspaceState::Added
 						|| WorkspaceState == EWorkspaceState::Moved
 						|| WorkspaceState == EWorkspaceState::Copied

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
@@ -18,7 +18,7 @@ enum class EWorkspaceState
 	Unknown,
 	Ignored,
 	Controlled, // called "Pristine" in Perforce, "Unchanged" in Git, "Clean" in SVN
-	CheckedOut, // Checked-out, without telling if Changed or not
+	CheckedOutChanged, // Checked-out, with changes (or without knowing for older version of Unity Version Control)
 	Added,
 	Moved, // Renamed
 	Copied,

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
@@ -138,6 +138,8 @@ public:
 	virtual bool IsConflicted() const override;
 	virtual bool CanRevert() const override;
 
+	bool IsCheckedOutImplementation() const;
+
 public:
 	/** History of the item, if any */
 	TPlasticSourceControlHistory History;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
@@ -19,6 +19,7 @@ enum class EWorkspaceState
 	Ignored,
 	Controlled, // called "Pristine" in Perforce, "Unchanged" in Git, "Clean" in SVN
 	CheckedOutChanged, // Checked-out, with changes (or without knowing for older version of Unity Version Control)
+	CheckedOutUnchanged, // Checked-out with no changes (cannot be checked-in and can be reverted by UndoUnchanged)
 	Added,
 	Moved, // Renamed
 	Copied,

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
@@ -139,6 +139,7 @@ public:
 	virtual bool CanRevert() const override;
 
 	bool IsCheckedOutImplementation() const;
+	bool IsLocked() const;
 
 public:
 	/** History of the item, if any */

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -406,7 +406,7 @@ static EWorkspaceState StateFromPlasticStatus(const FString& InResult)
 	}
 	else if (FileStatus == "CO") // Checked-Out for modification
 	{
-		State = EWorkspaceState::CheckedOut;
+		State = EWorkspaceState::CheckedOutChanged;
 	}
 	else if (FileStatus == "CP")
 	{
@@ -1734,7 +1734,7 @@ EWorkspaceState ParseShelveFileStatus(const TCHAR InFileStatus)
 	}
 	else if (InFileStatus == 'C') // Changed (CheckedOut or not)
 	{
-		return EWorkspaceState::CheckedOut;
+		return EWorkspaceState::CheckedOutChanged;
 	}
 	else if (InFileStatus == 'M') // Moved/Renamed (or Locally Moved)
 	{

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -398,7 +398,8 @@ private:
 static EWorkspaceState StateFromPlasticStatus(const FString& InResult)
 {
 	EWorkspaceState State;
-	const FString FileStatus = (InResult[0] == TEXT(' ')) ? InResult.Mid(1, 2) : InResult;
+
+	const FString FileStatus = InResult.Mid(1, 2);
 
 	if (FileStatus == "CH") // Modified but not Checked-Out
 	{
@@ -1554,19 +1555,10 @@ bool RunUpdate(const TArray<FString>& InFiles, const bool bInIsPartialWorkspace,
 #if ENGINE_MAJOR_VERSION == 5
 
 /**
- * Parse results of the 'cm status --changelists --controlledchanged --xml --encoding="utf-8"' command.
+ * Parse results of the 'cm status --changelists --controlledchanged --noheader --xml --encoding="utf-8"' command.
  *
  * Results of the status changelists command looks like that:
 <StatusOutput>
-  <WorkspaceStatus>
-	<Status>
-	  <RepSpec>
-		<Server>test@cloud</Server>
-		<Name>UEPlasticPluginDev</Name>
-	  </RepSpec>
-	  <Changeset>11</Changeset>
-	</Status>
-  </WorkspaceStatus>
   <WkConfigType>Branch</WkConfigType>
   <WkConfigName>/main@rep:UEPlasticPluginDev@repserver:test@cloud</WkConfigName>
   <Changelists>
@@ -1648,8 +1640,7 @@ static bool ParseChangelistsResults(const FXmlFile& InXmlResult, TArray<FPlastic
 			{
 				check(ChangeNode);
 				const FXmlNode* PathNode = ChangeNode->FindChildNode(Path);
-				const FXmlNode* TypeNode = ChangeNode->FindChildNode(Type);
-				if (PathNode == nullptr || TypeNode == nullptr)
+				if (PathNode == nullptr)
 				{
 					continue;
 				}
@@ -1660,7 +1651,6 @@ static bool ParseChangelistsResults(const FXmlFile& InXmlResult, TArray<FPlastic
 				if (FileName.FindChar(TEXT('.'), DotIndex))
 				{
 					FPlasticSourceControlState FileState(FPaths::ConvertRelativePathToFull(WorkingDirectory, MoveTemp(FileName)));
-					FileState.WorkspaceState = PlasticSourceControlUtils::StateFromPlasticStatus(TypeNode->GetContent());
 					FileState.Changelist = ChangelistState.Changelist;
 					OutCLFilesStates[ChangelistIndex].Add(MoveTemp(FileState));
 				}

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -299,7 +299,7 @@ FString UserNameToDisplayName(const FString& InUserName)
 /**
  * @brief Extract the renamed from filename from a cm "status" result.
  *
- * Examples of status results:
+ * Examples of status results (note that it always state "100%"):
  MV 100% Content\ToMove_BP.uasset -> Content\Moved_BP.uasset
  *
  * @param[in] InResult One line of status
@@ -307,13 +307,13 @@ FString UserNameToDisplayName(const FString& InUserName)
  *
  * @see FilenameFromStatusResult()
  */
-static FString RenamedFromPlasticStatus(const FString& InResult)
+static FString RenamedFromStatusResult(const FString& InResult)
 {
 	FString RenamedFrom;
 	int32 RenameIndex;
 	if (InResult.FindLastChar(TEXT('>'), RenameIndex))
 	{
-		// Extract only the first part of a rename "from -> to" (after the 2 letters status surrounded by 2 spaces)
+		// Extract only the first part of a rename "from -> to" (after the 2 letters status and the 100%)
 		RenamedFrom = InResult.Mid(9, RenameIndex - 9 - 2);
 	}
 	return RenamedFrom;
@@ -331,7 +331,7 @@ static FString RenamedFromPlasticStatus(const FString& InResult)
  * @param[in] InResult One line of status
  * @return Relative filename extracted from the line of status
  *
- * @see FPlasticStatusFileMatcher and StateFromPlasticStatus()
+ * @see RenamedFromStatusResult, FPlasticStatusFileMatcher and StateFromStatus()
  */
 static FString FilenameFromStatusResult(const FString& InResult)
 {
@@ -549,7 +549,7 @@ static void ParseFileStatusResult(TArray<FString>&& InFiles, const TArray<FStrin
 			// Extract the original name of a Moved/Renamed file
 			if (EWorkspaceState::Moved == FileState.WorkspaceState)
 			{
-				FileState.MovedFrom = FPaths::ConvertRelativePathToFull(WorkingDirectory, RenamedFromPlasticStatus(InResults[IdxResult]));
+				FileState.MovedFrom = FPaths::ConvertRelativePathToFull(WorkingDirectory, RenamedFromStatusResult(InResults[IdxResult]));
 			}
 		}
 		else

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -566,7 +566,6 @@ static void ParseFileStatusResult(TArray<FString>&& InFiles, const TArray<FStrin
 				FileState.WorkspaceState = EWorkspaceState::Private; // Not Controlled
 			}
 		}
-		FileState.TimeStamp.Now();
 
 		// debug log (only for the first few files)
 		if (OutStates.Num() < 20)
@@ -611,7 +610,6 @@ static void ParseDirectoryStatusResultForDeleted(const TArray<FString>& InResult
 			FString AbsoluteFilename = FPaths::ConvertRelativePathToFull(WorkingDirectory, MoveTemp(RelativeFilename));
 			FPlasticSourceControlState FileState(MoveTemp(AbsoluteFilename));
 			FileState.WorkspaceState = WorkspaceState;
-			FileState.TimeStamp.Now();
 
 			UE_LOG(LogSourceControl, Verbose, TEXT("%s = %d:%s"), *FileState.LocalFilename, static_cast<uint32>(FileState.WorkspaceState), FileState.ToString());
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -710,8 +710,6 @@ static void ParseFileinfoResults(const TArray<FString>& InResults, TArray<FPlast
 {
 	TRACE_CPUPROFILER_EVENT_SCOPE(PlasticSourceControlUtils::ParseFileinfoResults);
 
-	const FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
-
 	ensureMsgf(InResults.Num() == InOutStates.Num(), TEXT("The fileinfo command should gives the same number of infos as the status command"));
 
 	// Iterate on all files and all status of the result (assuming same number of line of results than number of file states)

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlVersions.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlVersions.h
@@ -8,29 +8,34 @@
 /**
  * List of key versions of Unity Version Control enabling new features for "cm" CLI.
  *
- * Unity Version Control version strings in the form "X.Y.Z.C", ie Major.Minor.Patch.Changeset (as returned by GetPlasticScmVersion)
+ * Unity Version Control version strings in the form "X.Y.Z.C", ie Major.Minor.Patch.Build (as returned by GetPlasticScmVersion)
 */
 namespace PlasticSourceControlVersions
 {
-	// Oldest supported version of "cm" (from 2021/01/05)
+	// Oldest supported version of "cm"
 	// 9.0.16.4839 cm changelist 'persistent' flag now contain a '--' prefix.
-	// https://www.plasticscm.com/download/releasenotes/9.0.16.4839
+	// https://plasticscm.com/download/releasenotes/9.0.16.4839 (2021/01/05)
 	static FSoftwareVersion OldestSupported(TEXT("9.0.16.4839"));
 
 	// 11.0.16.7248 add support for --descriptionfile for multi-line descriptions and support for special characters
-	// https://www.plasticscm.com/download/releasenotes/11.0.16.7248
+	// https://plasticscm.com/download/releasenotes/11.0.16.7248 (2022/07/28)
 	static const FSoftwareVersion NewChangelistFileArgs(TEXT("11.0.16.7248"));
 
 	// 11.0.16.7504 add support for 'cm shelveset apply' to only unshelved the desired changes from a shelve
-	// https://www.plasticscm.com/download/releasenotes/11.0.16.7504
+	// https://plasticscm.com/download/releasenotes/11.0.16.7504 (2022/10/13)
 	static const FSoftwareVersion ShelvesetApplySelection(TEXT("11.0.16.7504"));
 
 	// 11.0.16.7608 add support for history --limit. It displays the N last revisions of the specified items.
-	// https://www.plasticscm.com/download/releasenotes/11.0.16.7608
+	// https://plasticscm.com/download/releasenotes/11.0.16.7608 (2022/11/07)
+	// NOTE: this is also the first version aware of Unreal Engine 5 "UnrealEditor.exe"
 	static const FSoftwareVersion NewHistoryLimit(TEXT("11.0.16.7608"));
 
-	// 11.0.16.7608 add support for undocheckout --keepchanges. It allows undo checkout and preserve all local changes.
-	// https://www.plasticscm.com/download/releasenotes/11.0.16.7665
+	// 11.0.16.7665 add support for undocheckout --keepchanges. It allows undo checkout and preserve all local changes.
+	// https://plasticscm.com/download/releasenotes/11.0.16.7665 (2022/12/01)
 	static const FSoftwareVersion UndoCheckoutKeepChanges(TEXT("11.0.16.7665"));
+	
+	// 11.0.16.7709 add support for status --iscochanged. It uses "CO+CH" vs "CO" to distinguish CheckedOut with/without changes.
+	// https://plasticscm.com/download/releasenotes/11.0.16.7709 (2023/01/12)
+	static const FSoftwareVersion StatusIsCheckedOutChanged(TEXT("11.0.16.7709"));
 
 } // namespace PlasticSourceControlVersions


### PR DESCRIPTION
Use the new status --iscochanged to distinguish assets checked out and changed "CO+CH" from those unchanged "CO".

- call "status" with the new --iscochanged flag if cm is recent enough
- parse the new "CO+CH" status
- also remove one wrong parsing of file status done in changelist status update

- WIP: keep the "changed" status into a new boolean flag vs as a new state in the EWorkspaceState enum

Requires Unity Version Control (formerly Plastic SCM) version 11.0.16.7709 released on 2023/01/12