### PR TITLE
Prevent shelving a file that is checked-out but without any change

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -1842,10 +1842,12 @@ bool FPlasticShelveWorker::Execute(FPlasticSourceControlCommand& InCommand)
 		// Remove unmodified files from the list of files to shelve
 		for (int32 i = 0; i < FilesToShelve.Num(); i++)
 		{
-			const FString& FileToShelve = FilesToShelve[i];
+			FString& FileToShelve = FilesToShelve[i];
 			TSharedRef<FPlasticSourceControlState, ESPMode::ThreadSafe> FileState = GetProvider().GetStateInternal(FileToShelve);
 			if (!FileState->IsModified())
 			{
+				FPaths::MakePathRelativeTo(FileToShelve, *FPaths::ProjectDir());
+				UE_LOG(LogSourceControl, Warning, TEXT("The file /%s is unchanged, it cannot be shelved."), *FileToShelve);
 				FilesToShelve.RemoveAt(i);
 			}
 		}
@@ -1858,6 +1860,7 @@ bool FPlasticShelveWorker::Execute(FPlasticSourceControlCommand& InCommand)
 		}
 		else
 		{
+			UE_LOG(LogSourceControl, Error, TEXT("No file to Shelve"));
 			InCommand.bCommandSuccessful = false;
 		}
 		if (InCommand.bCommandSuccessful)

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -1840,11 +1840,16 @@ bool FPlasticShelveWorker::Execute(FPlasticSourceControlCommand& InCommand)
 	if (InCommand.bCommandSuccessful)
 	{
 		// Remove unmodified files from the list of files to shelve
-		for (int32 i = 0; i < FilesToShelve.Num(); i++)
+		int32 i = 0;
+		while (i < FilesToShelve.Num())
 		{
 			FString& FileToShelve = FilesToShelve[i];
 			TSharedRef<FPlasticSourceControlState, ESPMode::ThreadSafe> FileState = GetProvider().GetStateInternal(FileToShelve);
-			if (!FileState->IsModified())
+			if (FileState->IsModified())
+			{
+				i++;
+			}
+			else
 			{
 				FPaths::MakePathRelativeTo(FileToShelve, *FPaths::ProjectDir());
 				UE_LOG(LogSourceControl, Warning, TEXT("The file /%s is unchanged, it cannot be shelved."), *FileToShelve);

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -1856,6 +1856,10 @@ bool FPlasticShelveWorker::Execute(FPlasticSourceControlCommand& InCommand)
 		{
 			InCommand.bCommandSuccessful = CreateShelve(Changelist.GetName(), ChangelistDescription, FilesToShelve, ShelveId, InCommand.ErrorMessages);
 		}
+		else
+		{
+			InCommand.bCommandSuccessful = false;
+		}
 		if (InCommand.bCommandSuccessful)
 		{
 			InChangelistToUpdate = InCommand.Changelist;
@@ -1879,6 +1883,7 @@ bool FPlasticShelveWorker::Execute(FPlasticSourceControlCommand& InCommand)
 				}
 
 				DeleteChangelist(GetProvider(), Changelist, InCommand.InfoMessages, InCommand.ErrorMessages);
+				GetProvider().RemoveChangelistFromCache(Changelist);
 			}
 		}
 	}


### PR DESCRIPTION
1. In case multiple checked-out files in a changelist are shelved at once, only try to put in the shelves the files that contain actual changes, since Unity Version Control (formerly Plastic SCM) won't let them in (before the fix it was silently succeeding but the file was in fact not in the shelve and a refresh of the UI would see it disappear)
2. In case all files are unchanged, don't even create the shelve if no files are left to shelve, in order to avoid dangling shelve/leaking them since they are not visible in the UI of Unreal

