### PR TITLE
Fix the parser of status warning message so that the perf tips is readable to the end user

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -490,7 +490,7 @@ static EWorkspaceState StateFromStatusResult(const FString& InResult, const bool
 	}
 	else
 	{
-		UE_LOG(LogSourceControl, Warning, TEXT("Unknown file status '%s' (in line '%s')"), *FileStatus, *InResult);
+		UE_LOG(LogSourceControl, Warning, TEXT("%s"), *InResult);
 		State = EWorkspaceState::Unknown;
 	}
 


### PR DESCRIPTION
Instead of a duplicated and convoluted message mostly unreadable

> Warning: Unknown file status 'Finding changed files took too long. Perf tips: [...]' (in line 'Finding changed files took too long. Perf tips: [...]')

the log now directly displays the warning from cm:

> Warning: Unknown file status 'Finding changed files took too long. Perf tips: https://www.plasticscm.com/download/help/statusperfhintschanged