### PR TITLE
Fix performance issue with the diff of assets

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlRevision.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlRevision.cpp
@@ -2,7 +2,6 @@
 
 #include "PlasticSourceControlRevision.h"
 #include "PlasticSourceControlModule.h"
-#include "PlasticSourceControlProvider.h"
 #include "PlasticSourceControlState.h"
 #include "PlasticSourceControlUtils.h"
 #include "SPlasticSourceControlSettings.h"
@@ -52,8 +51,6 @@ bool FPlasticSourceControlRevision::Get(FString& InOutFilename, EConcurrency::Ty
 	}
 	else if (State)
 	{
-		const FString& PathToPlasticBinary = FPlasticSourceControlModule::Get().GetProvider().AccessSettings().GetBinaryPath();
-
 		FString RevisionSpecification;
 		if (ShelveId != ISourceControlState::INVALID_REVISION)
 		{
@@ -66,7 +63,7 @@ bool FPlasticSourceControlRevision::Get(FString& InOutFilename, EConcurrency::Ty
 			// Format the revision specification of the checked-in file, like rev:Content/BP.uasset#cs:12@repo@server:8087
 			RevisionSpecification = FString::Printf(TEXT("rev:%s#cs:%d@%s"), *Filename, ChangesetNumber, *State->RepSpec);
 		}
-		bCommandSuccessful = PlasticSourceControlUtils::RunDumpToFile(PathToPlasticBinary, RevisionSpecification, InOutFilename);
+		bCommandSuccessful = PlasticSourceControlUtils::RunGetFile(RevisionSpecification, InOutFilename);
 	}
 	else
 	{

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
@@ -146,12 +146,11 @@ bool RunUpdateStatus(const TArray<FString>& InFiles, const EStatusSearchType InS
 /**
  * Run a Plastic "cat" command to dump the binary content of a revision into a file.
  *
- * @param	InPathToPlasticBinary	The path to the Plastic binary
  * @param	InRevSpec				The revision specification to get
  * @param	InDumpFileName			The temporary file to dump the revision
  * @returns true if the command succeeded and returned no errors
 */
-bool RunDumpToFile(const FString& InPathToPlasticBinary, const FString& InRevSpec, const FString& InDumpFileName);
+bool RunGetFile(const FString& InRevSpec, const FString& InDumpFileName);
 
 /**
  * Run Plastic "history" and "log" commands and parse their XML results.


### PR DESCRIPTION
Rename RunDumpToFile() to RunGetFile()
Remove its first parameter InPathToPlasticBinary
Make it call "getfile" on the background shell instead of executing a new dedicated cm process