### PR TITLE
Use 'status --machinereadable' instead of the legacy '--compact' mode

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -130,9 +130,8 @@ bool FPlasticConnectWorker::Execute(FPlasticSourceControlCommand& InCommand)
 		InCommand.bCommandSuccessful = PlasticSourceControlUtils::GetWorkspaceName(InCommand.PathToWorkspaceRoot, InCommand.WorkspaceName, InCommand.ErrorMessages);
 		if (InCommand.bCommandSuccessful)
 		{
-			// Get repository, server URL, branch and current changeset number
-			// Note: this initiates the connection to the server and issue network calls, so we don't need an explicit 'checkconnection'
-			InCommand.bCommandSuccessful = PlasticSourceControlUtils::GetWorkspaceInformation(InCommand.ChangesetNumber, InCommand.RepositoryName, InCommand.ServerUrl, InCommand.BranchName, InCommand.ErrorMessages);
+			// Get current branch, repository, server URL and check the connection
+			InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCheckConnection(InCommand.BranchName, InCommand.RepositoryName, InCommand.ServerUrl, InCommand.InfoMessages, InCommand.ErrorMessages);
 			if (InCommand.bCommandSuccessful)
 			{
 				InCommand.InfoMessages.Add(TEXT("Connected successfully"));
@@ -923,16 +922,9 @@ bool FPlasticUpdateStatusWorker::Execute(FPlasticSourceControlCommand& InCommand
 		PlasticSourceControlUtils::RemoveRedundantErrors(InCommand, TEXT("is not in a workspace."));
 		if (!InCommand.bCommandSuccessful)
 		{
-			TArray<FString> ErrorMessages;
-			TArray<FString> Parameters;
-			FString BranchName, RepositoryName, ServerUrl;
-			if (PlasticSourceControlUtils::GetWorkspaceInfo(BranchName, RepositoryName, ServerUrl, ErrorMessages))
-			{
-				Parameters.Add(FString::Printf(TEXT("--server=%s"), *ServerUrl));
-			}
-			UE_LOG(LogSourceControl, Error, TEXT("FPlasticUpdateStatusWorker(ErrorMessages.Num()=%d) => checkconnection"), InCommand.ErrorMessages.Num());
-			// In case of error, execute a 'checkconnection' command to check the connectivity of the server.
-			InCommand.bConnectionDropped = !PlasticSourceControlUtils::RunCommand(TEXT("checkconnection"), Parameters, TArray<FString>(), InCommand.InfoMessages, InCommand.ErrorMessages);
+			// In case of error, execute a 'checkconnection' command to check the connection to the server.
+			UE_LOG(LogSourceControl, Warning, TEXT("Error on 'status', execute a 'checkconnection' to test the connection to the server"));
+			InCommand.bConnectionDropped = !PlasticSourceControlUtils::RunCheckConnection(InCommand.BranchName, InCommand.RepositoryName, InCommand.ServerUrl, InCommand.InfoMessages, InCommand.ErrorMessages);
 			return false;
 		}
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
@@ -66,15 +66,10 @@ void FPlasticSourceControlProvider::Init(bool bForceConnection)
 
 	if (bForceConnection && bPlasticAvailable && bWorkspaceFound && !bServerAvailable)
 	{
-		// Execute a 'checkconnection' command to set bServerAvailable based on the connectivity of the server
 		TArray<FString> InfoMessages, ErrorMessages;
 		TArray<FString> Parameters;
-		if (PlasticSourceControlUtils::GetWorkspaceInfo(BranchName, RepositoryName, ServerUrl, ErrorMessages))
-		{
-			Parameters.Add(FString::Printf(TEXT("--server=%s"), *ServerUrl));
-		}
-		// TODO check how long this takes, I suspect that it's much faster than the later call to "status" in the "Connect" operation; check on bigger projects!
-		bServerAvailable = PlasticSourceControlUtils::RunCommand(TEXT("checkconnection"), Parameters, TArray<FString>(), InfoMessages, ErrorMessages);
+		// Execute a 'checkconnection' command to set bServerAvailable based on the connectivity of the server
+		bServerAvailable = PlasticSourceControlUtils::RunCheckConnection(BranchName, RepositoryName, ServerUrl, InfoMessages, ErrorMessages);
 		if (!bServerAvailable)
 		{
 			FMessageLog SourceControlLog("SourceControl");
@@ -227,6 +222,8 @@ FText FPlasticSourceControlProvider::GetStatusText() const
 	Args.Add(TEXT("WorkspacePath"), FText::FromString(PathToWorkspaceRoot));
 	Args.Add(TEXT("WorkspaceName"), FText::FromString(WorkspaceName));
 	Args.Add(TEXT("BranchName"), FText::FromString(BranchName));
+	Args.Add(TEXT("RepositoryName"), FText::FromString(RepositoryName));
+	Args.Add(TEXT("ServerUrl"), FText::FromString(ServerUrl));
 	// Detect special case for a partial checkout (CS:-1 in Gluon mode)!
 	if (IsPartialWorkspace())
 	{
@@ -258,7 +255,7 @@ FText FPlasticSourceControlProvider::GetStatusText() const
 	}
 	Args.Add(TEXT("ErrorText"), FormattedError);
 
-	return FText::Format(LOCTEXT("PlasticStatusText", "{ErrorText}Unity Version Control (formerly Plastic SCM) {PlasticScmVersion}\t(plugin v{PluginVersion})\nWorkspace: {WorkspaceName}  ({WorkspacePath})\n{BranchName}\nChangeset: {ChangesetNumber}\nUser: '{UserName}'  {DisplayName}"), Args);
+	return FText::Format(LOCTEXT("PlasticStatusText", "{ErrorText}Unity Version Control (formerly Plastic SCM) {PlasticScmVersion}\t(plugin v{PluginVersion})\nWorkspace: {WorkspaceName}  ({WorkspacePath})\nBranch: {BranchName}@{RepositoryName}@{ServerUrl}\nChangeset: {ChangesetNumber}\nUser: '{UserName}'  {DisplayName}"), Args);
 }
 
 /** Quick check if source control is enabled. Specifically, it returns true if a source control provider is set (regardless of whether the provider is available) and false if no provider is set. So all providers except the stub DefaultSourceProvider will return true. */

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -260,13 +260,13 @@ static bool ParseWorkspaceInfo(const TArray<FString>& InResults, FString& OutBra
 	return true;
 }
 
-bool GetWorkspaceInfo(FString& OutRepositoryName, FString& OutServerUrl, FString& OutBranchName, TArray<FString>& OutErrorMessages)
+bool GetWorkspaceInfo(FString& OutBranchName, FString& OutRepositoryName, FString& OutServerUrl, TArray<FString>& OutErrorMessages)
 {
 	TArray<FString> Results;
 	bool bResult = RunCommand(TEXT("workspaceinfo"), TArray<FString>(), TArray<FString>(), Results, OutErrorMessages);
 	if (bResult)
 	{
-		bResult = ParseWorkspaceInfo(Results, OutRepositoryName, OutServerUrl, OutBranchName);
+		bResult = ParseWorkspaceInfo(Results, OutBranchName, OutRepositoryName, OutServerUrl);
 	}
 
 	return bResult;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
@@ -59,7 +59,7 @@ bool GetConfigSetFilesAsReadOnly();
 void GetUserName(FString& OutUserName);
 
 /**
- * Get Plastic workspace name
+ * Get workspace name
  * @param	InWorkspaceRoot		The workspace from where to run the command - usually the Game directory
  * @param	OutWorkspaceName	Name of the current workspace
  * @param	OutErrorMessages	Any errors (from StdErr) as an array per-line
@@ -67,26 +67,25 @@ void GetUserName(FString& OutUserName);
 bool GetWorkspaceName(const FString& InWorkspaceRoot, FString& OutWorkspaceName, TArray<FString>& OutErrorMessages);
 
 /**
- * Get Plastic repository name and server URL, branch name and current changeset number
- * @param	OutChangeset		The current Changeset Number
- * @param	OutRepositoryName	Name of the repository of the current workspace
- * @param	OutServerUrl		URL/Port of the server of the repository
- * @param	OutBranchName		Name of the current checked-out branch
- * @param	OutErrorMessages	Any errors (from StdErr) as an array per-line
- */
-bool GetWorkspaceInformation(int32& OutChangeset, FString& OutRepositoryName, FString& OutServerUrl, FString& OutBranchName, TArray<FString>& OutErrorMessages);
-
-/**
- * Get Plastic repository name, server URL, and branch name
- *
- * Note: this is a local fast variant, not making network call to the server.
+ * Get workspace info: the current branch, repository name, and server URL
  * 
- * @param	OutBranchName		Name of the current checked-out branch
+ * @param	OutBranchName		Name of the current branch
  * @param	OutRepositoryName	Name of the repository of the current workspace
  * @param	OutServerUrl		URL/Port of the server of the repository
  * @param	OutErrorMessages	Any errors (from StdErr) as an array per-line
  */
 bool GetWorkspaceInfo(FString& OutBranchName, FString& OutRepositoryName, FString& OutServerUrl, TArray<FString>& OutErrorMessages);
+
+/**
+ * Get workspace info and check the connection to the server
+ *
+ * @param	OutBranchName		Name of the current branch
+ * @param	OutRepositoryName	Name of the repository of the current workspace
+ * @param	OutServerUrl		URL/Port of the server of the repository
+ * @param	OutInfoMessages		Result of the connection test
+ * @param	OutErrorMessages	Any errors (from StdErr) as an array per-line
+ */
+bool RunCheckConnection(FString& OutBranchName, FString& OutRepositoryName, FString& OutServerUrl, TArray<FString>& OutInfoMessages, TArray<FString>& OutErrorMessages);
 
 /**
  * Use the Project Settings to replace Unity Version Control full username/e-mail by a shorter version for display.


### PR DESCRIPTION
In order to manage superimposed states like "CO+RP+CH" and thus fix the state of unshelved files.

- Fix ParseWorkspaceInfo() to also handle the case where the workspace has been switched to a Changeset instead of a Branch
- Remove the old GetWorkspaceInformation() and use instead a new RunCheckConnection() inside the "Connect" operation that wraps cleanly GetWorkspaceInfo() and the call to "checkconnection"
- Use 'status --machinereadable' instead of the legacy '--compact' mode in order to manage superimposed states like "CO+RP+CH"
    - New GetChangesetFromWorkspaceStatus() to update Changeset instead of the old full ParseWorkspaceInformation()
    - Update StateFromStatusResult() to parse the status into an array of status elements using ";" as a separator
    - Split it into a StateFromStatus() to handle all the 2-to-8 file status
