### PR TITLE
Add support for the Changelist Review editor plugin in UE5.2

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -25,10 +25,6 @@
 
 #define LOCTEXT_NAMESPACE "PlasticSourceControl"
 
-//TODO REVIEW
-UE_DISABLE_OPTIMIZATION
-
-
 template<typename Type>
 static FPlasticSourceControlWorkerRef InstantiateWorker(FPlasticSourceControlProvider& PlasticSourceControlProvider)
 {
@@ -2272,9 +2268,5 @@ bool FPlasticGetFileWorker::UpdateStates()
 }
 
 #endif
-
-
-//TODO REVIEW
-UE_ENABLE_OPTIMIZATION
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -25,6 +25,10 @@
 
 #define LOCTEXT_NAMESPACE "PlasticSourceControl"
 
+//TODO REVIEW
+UE_DISABLE_OPTIMIZATION
+
+
 template<typename Type>
 static FPlasticSourceControlWorkerRef InstantiateWorker(FPlasticSourceControlProvider& PlasticSourceControlProvider)
 {
@@ -59,6 +63,9 @@ void IPlasticSourceControlWorker::RegisterWorkers(FPlasticSourceControlProvider&
 	PlasticSourceControlProvider.RegisterWorker("Shelve", FGetPlasticSourceControlWorker::CreateStatic(&InstantiateWorker<FPlasticShelveWorker>));
 	PlasticSourceControlProvider.RegisterWorker("Unshelve", FGetPlasticSourceControlWorker::CreateStatic(&InstantiateWorker<FPlasticUnshelveWorker>));
 	PlasticSourceControlProvider.RegisterWorker("DeleteShelved", FGetPlasticSourceControlWorker::CreateStatic(&InstantiateWorker<FPlasticDeleteShelveWorker>));
+
+	PlasticSourceControlProvider.RegisterWorker("GetChangelistDetails", FGetPlasticSourceControlWorker::CreateStatic(&InstantiateWorker<FPlasticGetChangelistDetailsWorker>));
+	PlasticSourceControlProvider.RegisterWorker("GetFile", FGetPlasticSourceControlWorker::CreateStatic(&InstantiateWorker<FPlasticGetFileWorker>));
 #endif
 }
 
@@ -2130,6 +2137,144 @@ bool FPlasticDeleteShelveWorker::UpdateStates()
 	}
 }
 
+// Copied from SSourceControlReview.cpp of the ChangelistReview Editor plugin
+namespace ReviewHelpers
+{
+	const FString FileDepotKey = TEXT("depotFile");
+	const FString FileRevisionKey = TEXT("rev");
+	const FString FileActionKey = TEXT("action");
+	const FString TimeKey = TEXT("time");
+	const FString AuthorKey = TEXT("user");
+	const FString DescriptionKey = TEXT("desc");
+	const FString ChangelistStatusKey = TEXT("status");
+	const FString ChangelistPendingStatusKey = TEXT("pending");
+	constexpr int32 RecordIndex = 0;
+}
+
+FName FPlasticGetChangelistDetailsWorker::GetName() const
+{
+	return "GetChangelistDetails";
+}
+
+bool FPlasticGetChangelistDetailsWorker::Execute(FPlasticSourceControlCommand& InCommand)
+{
+	TRACE_CPUPROFILER_EVENT_SCOPE(FPlasticGetChangelistDetailsWorker::Execute);
+
+	TSharedRef<FGetChangelistDetails, ESPMode::ThreadSafe> Operation = StaticCastSharedRef<FGetChangelistDetails>(InCommand.Operation);
+
+	// Note: Changelists are local construct so we have to interpret this as a Shelve Id instead
+	const FString& ShelveId = Operation->GetChangelistNumber();
+	if (ShelveId.IsEmpty())
+	{
+		InCommand.bCommandSuccessful = false;
+		InCommand.ErrorMessages.Add((LOCTEXT("GetChangelistDetailsEmptyId", "GetChangelistDetails failed. Shelve Id is empty.").ToString()));
+		return false;
+	}
+
+	FString Comment;
+	FString Owner;
+	FDateTime Date;
+	TArray<FPlasticSourceControlState> States;
+
+	InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunGetShelve(FCString::Atoi(*ShelveId), Comment, Date, Owner, States, InCommand.ErrorMessages);
+	if (!InCommand.bCommandSuccessful)
+	{
+		InCommand.bCommandSuccessful = false;
+		InCommand.ErrorMessages.Add((LOCTEXT("GetChangelistDetailsInvalidId", "GetChangelistDetails failed. Shelve Id is invalid.").ToString()));
+		return false;
+	}
+
+	UE_LOG(LogSourceControl, Log, TEXT("GetChangelistDetails: %d files in shelve %s"), States.Num(), *ShelveId);
+
+	TMap<FString, FString> Record;
+
+	Record.Add({ ReviewHelpers::ChangelistStatusKey, ReviewHelpers::ChangelistPendingStatusKey });
+	Record.Add({ ReviewHelpers::AuthorKey, Owner });
+	Record.Add({ ReviewHelpers::DescriptionKey, Comment });
+	Record.Add({ ReviewHelpers::TimeKey, LexToString(Date.ToUnixTimestamp()) });
+
+	uint32  RecordFileIndex = 0;
+	for (auto& State : States)
+	{
+		// String representation of the current file index
+		FString RecordFileIndexStr = LexToString(RecordFileIndex);
+		// The p4 records is the map a file key starts with "depotFile" and is followed by file index 
+		FString RecordFileMapKey = ReviewHelpers::FileDepotKey + RecordFileIndexStr;
+		// The p4 records is the map a revision key starts with "rev" and is followed by file index 
+		FString RecordRevisionMapKey = ReviewHelpers::FileRevisionKey + RecordFileIndexStr;
+		// The p4 records is the map a revision key starts with "action" and is followed by file index 
+		FString RecordActionMapKey = ReviewHelpers::FileActionKey + RecordFileIndexStr;
+
+		check(State.History.Num() == 1);
+		TSharedPtr<FPlasticSourceControlRevision, ESPMode::ThreadSafe> Revision = State.History[0];
+
+		UE_LOG(LogSourceControl, Log, TEXT("GetChangelistDetails: %s revid:%d action:%s"), *Revision->Filename, Revision->RevisionId, *Revision->Action);
+
+		Record.Add({ MoveTemp(RecordFileMapKey), MoveTemp(Revision->Filename) });
+		Record.Add({ MoveTemp(RecordRevisionMapKey), LexToString(Revision->RevisionId) });
+		Record.Add({ MoveTemp(RecordActionMapKey), Revision->Action });
+
+		RecordFileIndex++;
+	}
+
+	TArray<TMap<FString, FString>> ChangelistRecord;
+	ChangelistRecord.Add(MoveTemp(Record));
+	Operation->SetChangelistDetails(MoveTemp(ChangelistRecord));
+
+	return InCommand.bCommandSuccessful;
+}
+
+bool FPlasticGetChangelistDetailsWorker::UpdateStates()
+{
+	return false;
+}
+
+FName FPlasticGetFileWorker::GetName() const
+{
+	return "GetFile";
+}
+
+bool FPlasticGetFileWorker::Execute(FPlasticSourceControlCommand& InCommand)
+{
+	TRACE_CPUPROFILER_EVENT_SCOPE(FPlasticGetChangelistDetailsWorker::FPlasticGetFileWorker);
+
+	TSharedRef<FGetFile, ESPMode::ThreadSafe> Operation = StaticCastSharedRef<FGetFile>(InCommand.Operation);
+
+	const TSharedRef<FPlasticSourceControlRevision, ESPMode::ThreadSafe> SourceControlRevision = MakeShared<FPlasticSourceControlRevision>();
+	SourceControlRevision->Filename = FPaths::ConvertRelativePathToFull(Operation->GetDepotFilePath());
+
+	if (Operation->IsShelve())
+	{
+		SourceControlRevision->ShelveId = FCString::Atoi(*Operation->GetChangelistNumber());
+		UE_LOG(LogSourceControl, Log, TEXT("GetFile(ShelveId:%d)"), SourceControlRevision->ShelveId);
+	}
+	else
+	{
+		SourceControlRevision->RevisionId = FCString::Atoi(*Operation->GetRevisionNumber());
+		UE_LOG(LogSourceControl, Log, TEXT("GetFile(revid:%d)"), SourceControlRevision->RevisionId);
+	}
+	
+	FString OutFilename;
+
+	InCommand.bCommandSuccessful = SourceControlRevision->Get(OutFilename, InCommand.Concurrency);
+
+	if (InCommand.bCommandSuccessful)
+	{
+		Operation->SetOutPackageFilename(OutFilename);
+	}
+
+	return InCommand.bCommandSuccessful;
+}
+
+bool FPlasticGetFileWorker::UpdateStates()
+{
+	return false;
+}
+
 #endif
+
+
+//TODO REVIEW
+UE_ENABLE_OPTIMIZATION
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
@@ -515,4 +515,32 @@ protected:
 	int32 ShelveId = ISourceControlState::INVALID_REVISION;
 };
 
+class FPlasticGetChangelistDetailsWorker final : public IPlasticSourceControlWorker
+{
+public:
+	FPlasticGetChangelistDetailsWorker(FPlasticSourceControlProvider& InSourceControlProvider)
+		: IPlasticSourceControlWorker(InSourceControlProvider)
+	{}
+	virtual ~FPlasticGetChangelistDetailsWorker() = default;
+
+	// IPlasticSourceControlWorker interface
+	virtual FName GetName() const override;
+	virtual bool Execute(FPlasticSourceControlCommand& InCommand) override;
+	virtual bool UpdateStates() override;
+};
+
+class FPlasticGetFileWorker final : public IPlasticSourceControlWorker
+{
+public:
+	FPlasticGetFileWorker(FPlasticSourceControlProvider& InSourceControlProvider)
+		: IPlasticSourceControlWorker(InSourceControlProvider)
+	{}
+	virtual ~FPlasticGetFileWorker() = default;
+
+	// IPlasticSourceControlWorker interface
+	virtual FName GetName() const override;
+	virtual bool Execute(FPlasticSourceControlCommand& InCommand) override;
+	virtual bool UpdateStates() override;
+};
+
 #endif

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlRevision.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlRevision.h
@@ -13,8 +13,8 @@ class FPlasticSourceControlRevision : public ISourceControlRevision
 {
 public:
 	FPlasticSourceControlRevision()
-		: ChangesetNumber(0)
-		, RevisionId(0)
+		: ChangesetNumber(ISourceControlState::INVALID_REVISION)
+		, RevisionId(ISourceControlState::INVALID_REVISION)
 		, Date(0)
 		, FileSize(0)
 	{

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -262,7 +262,6 @@ FString UserNameToDisplayName(const FString& InUserName)
 	return InUserName;
 }
 
-
 /**
 * Parse the current changeset from the header returned by "cm status --machinereadable --header --fieldseparator=;"
 *
@@ -2013,6 +2012,7 @@ bool RunGetShelveFiles(const int32 InShelveId, TArray<FPlasticSourceControlState
 		TArray<FString> Parameters;
 		Parameters.Add(FString::Printf(TEXT("sh:%d"), InShelveId));
 		Parameters.Add(TEXT("--format=\"{status};{baserevid};{path}\""));
+		Parameters.Add(TEXT("--encoding=\"utf-8\""));
 		const bool bDiffSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("diff"), Parameters, TArray<FString>(), Results, OutErrorMessages);
 		if (bDiffSuccessful)
 		{

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -1210,7 +1210,6 @@ static bool ParseHistoryResults(const bool bInUpdateHistory, const FXmlFile& InX
 #endif
 				SourceControlRevision->State = &InOutState;
 				SourceControlRevision->Filename = Filename;
-				SourceControlRevision->RevisionId = Index + 1;
 
 				if (const FXmlNode* RevisionTypeNode = RevisionNode->FindChildNode(RevisionType))
 				{

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
@@ -193,10 +193,10 @@ bool RunGetShelves(TArray<FPlasticSourceControlChangelistState>& InOutChangelist
  * @param	OutComment			Shelve Comment
  * @param	OutDate				Shelve Date
  * @param	OutOwner			Shelve Owner
- * @param	OutStates			Files in the shelve and their state, including base revision id
+ * @param	OutStates			Files in the shelve and their base revision id
  * @param	OutErrorMessages	Any errors (from StdErr) as an array per-line
  */
-bool RunGetShelve(const int32 InShelveId, FString& OutComment, FDateTime& OutDate, FString& OutOwner, TArray<FPlasticSourceControlState>& OutStates, TArray<FString>& OutErrorMessages);
+bool RunGetShelve(const int32 InShelveId, FString& OutComment, FDateTime& OutDate, FString& OutOwner, TArray<FPlasticSourceControlRevision>& OutBaseRevisions, TArray<FString>& OutErrorMessages);
 
 /**
  * Add a file to the shelve associated with a changelist.

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
@@ -188,6 +188,17 @@ bool RunGetChangelists(TArray<FPlasticSourceControlChangelistState>& OutChangeli
 bool RunGetShelves(TArray<FPlasticSourceControlChangelistState>& InOutChangelistsStates, TArray<FString>& OutErrorMessages);
 
 /**
+ * Run find "shelves where ShelveId='NNN'" and a "diff sh:<ShelveId>" and parse their results.
+ * @param	InShelveId			Shelve Id
+ * @param	OutComment			Shelve Comment
+ * @param	OutDate				Shelve Date
+ * @param	OutOwner			Shelve Owner
+ * @param	OutStates			Files in the shelve and their state, including base revision id
+ * @param	OutErrorMessages	Any errors (from StdErr) as an array per-line
+ */
+bool RunGetShelve(const int32 InShelveId, FString& OutComment, FDateTime& OutDate, FString& OutOwner, TArray<FPlasticSourceControlState>& OutStates, TArray<FString>& OutErrorMessages);
+
+/**
  * Add a file to the shelve associated with a changelist.
  * @param	InOutChangelistsState	The changelist to add the file to
  * @param	InFilename				The file to add to the shelve


### PR DESCRIPTION
Initial support for the new Changelist Review Tool editor plugin in UE5.2

- Revision can now dump/getfile the content of a specific RevisionId of a file
- MVP implementation of GetChangelistDetails & GetFile using ShelveId as key and Base RevisionId for proper diff