### PR TITLE
Fix crash ArrayIndexOutOfBoundsException when opening a project hosted On Prem

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -169,7 +169,7 @@ static bool ParseWorkspaceInfo(TArray<FString>& InResults, FString& OutBranchNam
 	}
 
 	// Get workspace information, in the form "Branch /main@UE5PlasticPluginDev@localhost:8087"
-	//                                     or "Branch /main@UE5PlasticPluginDev@test@cloud" (when connected directly to the cloud)
+	//                                     or "Branch /main@UE5PlasticPluginDev@test@cloud" (when connected to the cloud)
 	//                                     or "Branch /main@rep:UE5OpenWorldPerfTest@repserver:test@cloud"
 	//                                     or "Changeset 1234@UE5PlasticPluginDev@test@cloud" (when the workspace is switched on a changeset instead of a branch)
 	static const FString BranchPrefix(TEXT("Branch "));
@@ -208,7 +208,7 @@ static bool ParseWorkspaceInfo(TArray<FString>& InResults, FString& OutBranchNam
 			OutServerUrl.RightChopInline(RepserverPrefix.Len());
 		}
 
-		if (WorkspaceInfos.Num() >= 3)
+		if (WorkspaceInfos.Num() > 3) // (when connected to the cloud)
 		{
 			OutServerUrl.Append(TEXT("@"));
 			OutServerUrl.Append(MoveTemp(WorkspaceInfos[3]));


### PR DESCRIPTION
The bug was in PlasticSourceControlUtils::ParseWorkspaceInfo() when splitting the "WorkspaceInfo" on the separator '@', since there is only 4 parts to is when on the @cloud, compare:
- Branch /main@UE5PlasticPluginDev@test@cloud
- Branch /main@UE5PlasticPluginDev@localhost:8087

This function is called once at Init() of the source control provider, so it was crashing the whole Editor right after project load.

Reproduced with a server on localhost (like shown above)