### PR TITLE
Fix history & diff on a file that has been unshelved

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
@@ -110,7 +110,7 @@ FName FPlasticSourceControlState::GetIconName() const
 	{
 		return FName("Perforce.NotAtHeadRevision");
 	}
-	else if (WorkspaceState != EWorkspaceState::CheckedOutChanged && WorkspaceState != EWorkspaceState::CheckedOutUnchanged)
+	else if (!IsCheckedOutImplementation())
 	{
 		if (IsCheckedOutOther())
 		{
@@ -163,7 +163,7 @@ FName FPlasticSourceControlState::GetSmallIconName() const
 	{
 		return FName("Perforce.NotAtHeadRevision_Small");
 	}
-	else if (WorkspaceState != EWorkspaceState::CheckedOutChanged && WorkspaceState != EWorkspaceState::CheckedOutUnchanged)
+	else if (!IsCheckedOutImplementation())
 	{
 		if (IsCheckedOutOther())
 		{
@@ -220,7 +220,7 @@ FSlateIcon FPlasticSourceControlState::GetIcon() const
 	{
 		return FSlateIcon(FRevisionControlStyleManager::GetStyleSetName(), "RevisionControl.NotAtHeadRevision");
 	}
-	else if (WorkspaceState != EWorkspaceState::CheckedOutChanged && WorkspaceState != EWorkspaceState::CheckedOutUnchanged && WorkspaceState != EWorkspaceState::Conflicted)
+	else if (!IsCheckedOutImplementation())
 	{
 		if (IsCheckedOutOther())
 		{
@@ -238,7 +238,7 @@ FSlateIcon FPlasticSourceControlState::GetIcon() const
 	{
 		return FSlateIcon(FAppStyle::GetAppStyleSetName(), "Perforce.NotAtHeadRevision");
 	}
-	else if (WorkspaceState != EWorkspaceState::CheckedOutChanged && WorkspaceState != EWorkspaceState::CheckedOutUnchanged && WorkspaceState != EWorkspaceState::Conflicted)
+	else if (!IsCheckedOutImplementation())
 	{
 		if (IsCheckedOutOther())
 		{
@@ -361,7 +361,7 @@ FText FPlasticSourceControlState::GetDisplayName() const
 		return FText::Format(LOCTEXT("NotCurrent", "Not at the head revision CS:{0} {1} (local revision is CS:{2})"),
 			FText::AsNumber(DepotRevisionChangeset), FText::FromString(HeadUserName), FText::AsNumber(LocalRevisionChangeset, &NoCommas));
 	}
-	else if (WorkspaceState != EWorkspaceState::CheckedOutChanged && WorkspaceState != EWorkspaceState::CheckedOutUnchanged && WorkspaceState != EWorkspaceState::Conflicted)
+	else if (!IsCheckedOutImplementation())
 	{
 		if (IsCheckedOutOther())
 		{
@@ -422,7 +422,7 @@ FText FPlasticSourceControlState::GetDisplayTooltip() const
 		return FText::Format(LOCTEXT("NotCurrent_Tooltip", "Not at the head revision CS:{0} {1} (local revision is CS:{2})"),
 			FText::AsNumber(DepotRevisionChangeset), FText::FromString(HeadUserName), FText::AsNumber(LocalRevisionChangeset, &NoCommas));
 	}
-	else if (WorkspaceState != EWorkspaceState::CheckedOutChanged && WorkspaceState != EWorkspaceState::CheckedOutUnchanged && WorkspaceState != EWorkspaceState::Conflicted)
+	else if (!IsCheckedOutImplementation())
 	{
 		if (IsCheckedOutOther())
 		{

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -1292,6 +1292,15 @@ static bool ParseHistoryResults(const bool bInUpdateHistory, const FXmlFile& InX
 					SourceControlRevision->FileSize = FCString::Atoi(*SizeNode->GetContent());
 				}
 
+				// A negative RevisionHeadChangeset provided by fileinfo mean that the file has been unshelved;
+				// replace it by the changeset number of the first revision in the history (the more recent)
+				// Note: workaround to be able to show the history / the diff of a file that has been unshelved
+				// (but keeps the LocalRevisionChangeset to the negative changeset corresponding to the Shelve Id)
+				if (InOutState.DepotRevisionChangeset < 0)
+				{
+					InOutState.DepotRevisionChangeset = SourceControlRevision->ChangesetNumber;
+				}
+
 				// Detect and skip more recent changesets on other branches (ie above the RevisionHeadChangeset)
 				// since we usually don't want to display changes from other branches in the History window...
 				// except in case of a merge conflict, where the Editor expects the tip of the "source (remote)" branch to be at the top of the history!

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -323,11 +323,15 @@ static EWorkspaceState StateFromStatus(const FString& InFileStatus, const bool b
 	{
 		State = EWorkspaceState::CheckedOutChanged; // Recent version; here it's checkedout with changes
 	}
-	else if ((InFileStatus == "CP") || (InFileStatus == "CO+CP"))
+	else if (InFileStatus.Contains(TEXT("CP"))) // "CP", "CO+CP"
 	{
 		State = EWorkspaceState::Copied;
 	}
-	else if ((InFileStatus == "RP") || (InFileStatus == "CO+RP") || (InFileStatus == "CO+RP+CH"))
+	else if (InFileStatus.Contains(TEXT("MV"))) // "MV", "CO+MV", "CO+CH+MV", "CO+RP+MV"
+	{
+		State = EWorkspaceState::Moved; // Moved/Renamed
+	}
+	else if (InFileStatus.Contains(TEXT("RP"))) // "RP", "CO+RP", "CO+RP+CH", "CO+CH+RP"
 	{
 		State = EWorkspaceState::Replaced;
 	}
@@ -350,10 +354,6 @@ static EWorkspaceState StateFromStatus(const FString& InFileStatus, const bool b
 	else if (InFileStatus == "LD")
 	{
 		State = EWorkspaceState::LocallyDeleted; // Locally Deleted (ie. missing)
-	}
-	else if ((InFileStatus == "MV") || (InFileStatus == "CO+MV") || (InFileStatus == "CO+CH+MV") || (InFileStatus == "CO+RP+MV"))
-	{
-		State = EWorkspaceState::Moved; // Moved/Renamed
 	}
 	else
 	{


### PR DESCRIPTION
Negative LocalRevisionChangeset & RevisionHeadChangeset provided by fileinfo means that the file has been unshelved (replaced/merged);
when the plugin detects this, it replaces it by the changeset number of the first revision in the history (the more recent)
(but keeps the LocalRevisionChangeset to the negative changeset corresponding to the Shelve Id)

Also fixes related issues to correctly detect "replaced" states and display proper icons & tooltips in these situations