### PR TITLE
Fix visual diff failing to getfile if there is a space in the path

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -1108,7 +1108,7 @@ bool RunGetFile(const FString& InRevSpec, const FString& InDumpFileName)
 	FString Errors;
 
 	TArray<FString> Parameters;
-	Parameters.Add(InRevSpec);
+	Parameters.Add(FString::Printf(TEXT("\"%s\""), *InRevSpec));
 	Parameters.Add(TEXT("--raw"));
 	Parameters.Add(FString::Printf(TEXT("--file=\"%s\""), *InDumpFileName));
 	const bool bResult = PlasticSourceControlUtils::RunCommand(TEXT("getfile"), Parameters, TArray<FString>(), Results, Errors);


### PR DESCRIPTION
Fix missing double quotes around the RevSpec in PlasticSourceControlUtils::RunGetFile()

Fix https://github.com/SRombauts/UEPlasticPlugin/issues/130 Diff against Depot doesn't work if the path contains a space (regression in 1.8.1)

Bug introduced by PR #77 1003295-fix-getfile-perf-using-shell in commit 33e4af1a by Sébastien Rombauts, 2023/04/06:
    Fix performance issue with the diff of assets

    Rename RunDumpToFile() to RunGetFile()
    Remove its first parameter InPathToPlasticBinary
    Make it call "getfile" on the background shell instead of executing a new dedicated cm process

In the refactor I dropped by mistake the double quotes that surrounded the RevSpec in:
	FString FullCommand = TEXT("cat \"");
	FullCommand += InRevSpec;
	FullCommand += TEXT("\" --raw --file=\"");