### PR TITLE
User connected to a cloud server can open the Dashboard

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
@@ -644,7 +644,7 @@ void FPlasticSourceControlMenu::AddMenuExtension(FToolMenuSection& Menu)
 
 	int32 index = serverUrl.Find("@cloud");
 
-	if (index > -1)
+	if (index > INDEX_NONE)
 	{
 		const FString& organizationName = serverUrl.Left(index);
 
@@ -654,7 +654,11 @@ void FPlasticSourceControlMenu::AddMenuExtension(FToolMenuSection& Menu)
 #endif
 			LOCTEXT("PlasticLockRulesURL", "Configure Lock Rules"),
 			LOCTEXT("PlasticLockRulesURLTooltip", "Navigate to lock rules configuration page in the Unity Dashboard."),
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
 			FSlateIcon(FAppStyle::GetAppStyleSetName(), "PropertyWindow.Locked"),
+#else
+			FSlateIcon(FEditorStyle::GetStyleSetName(), "PropertyWindow.Locked"),
+#endif
 			FUIAction(
 				FExecuteAction::CreateRaw(this, &FPlasticSourceControlMenu::VisitLockRulesURLClicked, organizationName),
 				FCanExecuteAction()

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
@@ -640,13 +640,11 @@ void FPlasticSourceControlMenu::AddMenuExtension(FToolMenuSection& Menu)
 	);
 
 	FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
-	const FString& serverUrl = Provider.GetServerUrl();
-
-	int32 index = serverUrl.Find("@cloud");
-
-	if (index > INDEX_NONE)
+	const FString& ServerUrl = Provider.GetServerUrl();
+	const int32 CloudIndex = ServerUrl.Find(TEXT("@cloud"));
+	if (CloudIndex > INDEX_NONE)
 	{
-		const FString& organizationName = serverUrl.Left(index);
+		const FString& OrganizationName = ServerUrl.Left(CloudIndex);
 
 		Menu.AddMenuEntry(
 #if ENGINE_MAJOR_VERSION == 5
@@ -660,7 +658,7 @@ void FPlasticSourceControlMenu::AddMenuExtension(FToolMenuSection& Menu)
 			FSlateIcon(FEditorStyle::GetStyleSetName(), "PropertyWindow.Locked"),
 #endif
 			FUIAction(
-				FExecuteAction::CreateRaw(this, &FPlasticSourceControlMenu::VisitLockRulesURLClicked, organizationName),
+				FExecuteAction::CreateRaw(this, &FPlasticSourceControlMenu::VisitLockRulesURLClicked, OrganizationName),
 				FCanExecuteAction()
 			)
 		);

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
@@ -545,9 +545,10 @@ void FPlasticSourceControlMenu::AddMenuExtension(FToolMenuSection& Menu)
 		)
 	);
 
-#if ENGINE_MAJOR_VERSION == 5
 	Menu.AddMenuEntry(
+#if ENGINE_MAJOR_VERSION == 5
 		"SourceControlEditorPreferences",
+#endif
 		LOCTEXT("SourceControlEditorPreferences", "Editor Preferences - Source Control"),
 		LOCTEXT("SourceControlEditorPreferencesTooltip", "Open the Load & Save section with Source Control in the Editor Preferences."),
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
@@ -560,9 +561,8 @@ void FPlasticSourceControlMenu::AddMenuExtension(FToolMenuSection& Menu)
 			FCanExecuteAction()
 		)
 	);
-#endif
 
-#if ENGINE_MAJOR_VERSION == 5
+#if ENGINE_MAJOR_VERSION == 5 // Disable the "Source Control Project Settings" for UE4 since this section is new to UE5
 	Menu.AddMenuEntry(
 		"SourceControlProjectSettings",
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
@@ -356,11 +356,11 @@ void FPlasticSourceControlMenu::VisitSupportURLClicked() const
 
 void FPlasticSourceControlMenu::VisitLockRulesURLClicked(const FString InOrganizationName) const
 {
-	const FText organizationLockRulesURL = FText::Format(
-		FText::FromString("https://dashboard.unity3d.com/devops/organizations/default/plastic-scm/organizations/{0}/lock-rules"),
-		FText::FromString(InOrganizationName)
+	const FString OrganizationLockRulesURL = FString::Printf(
+		TEXT("https://dashboard.unity3d.com/devops/organizations/default/plastic-scm/organizations/%s/lock-rules"),
+		*InOrganizationName
 	);
-	FPlatformProcess::LaunchURL(*organizationLockRulesURL.ToString(), NULL, NULL);
+	FPlatformProcess::LaunchURL(*OrganizationLockRulesURL, NULL, NULL);
 }
 
 // Display an ongoing notification during the whole operation

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
@@ -354,18 +354,13 @@ void FPlasticSourceControlMenu::VisitSupportURLClicked() const
 	}
 }
 
-void FPlasticSourceControlMenu::VisitLockRulesURLClicked(const FString OrganizationName) const
+void FPlasticSourceControlMenu::VisitLockRulesURLClicked(const FString InOrganizationName) const
 {
-	// Grab the URL from the uplugin file
-	const TSharedPtr<IPlugin> Plugin = IPluginManager::Get().FindPlugin(TEXT("PlasticSourceControl"));
-	if (Plugin.IsValid())
-	{
-		const FText organizationLockRulesURL = FText::Format(
-			FText::FromString("https://dashboard.unity3d.com/devops/organizations/default/plastic-scm/organizations/{0}/lock-rules"),
-			FText::FromString(OrganizationName)
-		);
-		FPlatformProcess::LaunchURL(*organizationLockRulesURL.ToString(), NULL, NULL);
-	}
+	const FText organizationLockRulesURL = FText::Format(
+		FText::FromString("https://dashboard.unity3d.com/devops/organizations/default/plastic-scm/organizations/{0}/lock-rules"),
+		FText::FromString(InOrganizationName)
+	);
+	FPlatformProcess::LaunchURL(*organizationLockRulesURL.ToString(), NULL, NULL);
 }
 
 // Display an ongoing notification during the whole operation
@@ -647,9 +642,11 @@ void FPlasticSourceControlMenu::AddMenuExtension(FToolMenuSection& Menu)
 	FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
 	const FString& serverUrl = Provider.GetServerUrl();
 
-	if (serverUrl.Contains("@cloud"))
+	int32 index = serverUrl.Find("@cloud");
+
+	if (index > -1)
 	{
-		const FString& organizationName = serverUrl.Left(serverUrl.Find("@cloud"));
+		const FString& organizationName = serverUrl.Left(index);
 
 		Menu.AddMenuEntry(
 #if ENGINE_MAJOR_VERSION == 5
@@ -657,13 +654,7 @@ void FPlasticSourceControlMenu::AddMenuExtension(FToolMenuSection& Menu)
 #endif
 			LOCTEXT("PlasticLockRulesURL", "Configure Lock Rules"),
 			LOCTEXT("PlasticLockRulesURLTooltip", "Navigate to lock rules configuration page in the Unity Dashboard."),
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
 			FSlateIcon(FAppStyle::GetAppStyleSetName(), "PropertyWindow.Locked"),
-#elif ENGINE_MAJOR_VERSION == 5
-			FSlateIcon(FEditorStyle::GetStyleSetName(), "PropertyWindow.Locked"),
-#elif ENGINE_MAJOR_VERSION == 4
-			FSlateIcon(FEditorStyle::GetStyleSetName(), "PropertyWindow.Locked"),
-#endif
 			FUIAction(
 				FExecuteAction::CreateRaw(this, &FPlasticSourceControlMenu::VisitLockRulesURLClicked, organizationName),
 				FCanExecuteAction()

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.h
@@ -28,6 +28,7 @@ public:
 	void ShowSourceControlPlasticScmProjectSettings() const;
 	void VisitDocsURLClicked() const;
 	void VisitSupportURLClicked() const;
+	void VisitLockRulesURLClicked(const FString OrganizationName) const;
 
 private:
 	bool IsSourceControlConnected() const;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.h
@@ -28,7 +28,7 @@ public:
 	void ShowSourceControlPlasticScmProjectSettings() const;
 	void VisitDocsURLClicked() const;
 	void VisitSupportURLClicked() const;
-	void VisitLockRulesURLClicked(const FString OrganizationName) const;
+	void VisitLockRulesURLClicked(const FString InOrganizationName) const;
 
 private:
 	bool IsSourceControlConnected() const;


### PR DESCRIPTION
### What
Adds a new button to the global revision control menu to open Lock Rules in Unity's Dashboard if the workspace points to a cloud organization
### How
- It checks server's url and looks for @cloud to find out if it is a cloud organization.
- If positive if shows a new button saying "Configure Lock Rules" ("Navigate to lock rules configuration page in the Unity Dashboard.")
- If clicked on the button it launches a url pointing to Lock Rules configuration page for the cloud organization (using 'default' as generic id)