### PR TITLE
Display Smart Locks information in the Content Browser #134

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
@@ -119,13 +119,20 @@ FName FPlasticSourceControlState::GetIconName() const
 	{
 		return FName("Perforce.NotAtHeadRevision");
 	}
-	else if (!IsCheckedOutImplementation())
+
+	if (!IsCheckedOutImplementation())
 	{
 		if (IsCheckedOutOther())
 		{
 			return FName("Perforce.CheckedOutByOtherUser");
 		}
-		else if (IsModifiedInOtherBranch())
+
+		if (IsRetainedInOtherBranch())
+		{
+			return FName("Perforce.CheckedOutByOtherUserOtherBranch");
+		}
+
+		if (IsModifiedInOtherBranch())
 		{
 			return FName("Perforce.ModifiedOtherBranch");
 		}
@@ -172,13 +179,19 @@ FName FPlasticSourceControlState::GetSmallIconName() const
 	{
 		return FName("Perforce.NotAtHeadRevision_Small");
 	}
-	else if (!IsCheckedOutImplementation())
+	if (!IsCheckedOutImplementation())
 	{
 		if (IsCheckedOutOther())
 		{
 			return FName("Perforce.CheckedOutByOtherUser_Small");
 		}
-		else if (IsModifiedInOtherBranch())
+
+		if (IsRetainedInOtherBranch())
+		{
+			return FName("Perforce.CheckedOutByOtherUserOtherBranch_Small");
+		}
+
+		if (IsModifiedInOtherBranch())
 		{
 			return FName("Perforce.ModifiedOtherBranch_Small");
 		}
@@ -229,13 +242,20 @@ FSlateIcon FPlasticSourceControlState::GetIcon() const
 	{
 		return FSlateIcon(FRevisionControlStyleManager::GetStyleSetName(), "RevisionControl.NotAtHeadRevision");
 	}
-	else if (!IsCheckedOutImplementation())
+
+	if (!IsCheckedOutImplementation())
 	{
 		if (IsCheckedOutOther())
 		{
 			return FSlateIcon(FRevisionControlStyleManager::GetStyleSetName(), "RevisionControl.CheckedOutByOtherUser", NAME_None, "RevisionControl.CheckedOutByOtherUserBadge");
 		}
-		else if (IsModifiedInOtherBranch())
+
+		if (IsRetainedInOtherBranch())
+		{
+			return FSlateIcon(FRevisionControlStyleManager::GetStyleSetName(), "RevisionControl.CheckedOutByOtherUserOtherBranch", NAME_None, "RevisionControl.CheckedOutByOtherUserOtherBranchBadge");
+		}
+
+		if (IsModifiedInOtherBranch())
 		{
 			return FSlateIcon(FRevisionControlStyleManager::GetStyleSetName(), "RevisionControl.ModifiedOtherBranch", NAME_None, "RevisionControl.ModifiedBadge");
 		}
@@ -247,13 +267,20 @@ FSlateIcon FPlasticSourceControlState::GetIcon() const
 	{
 		return FSlateIcon(FAppStyle::GetAppStyleSetName(), "Perforce.NotAtHeadRevision");
 	}
-	else if (!IsCheckedOutImplementation())
+
+	if (!IsCheckedOutImplementation())
 	{
 		if (IsCheckedOutOther())
 		{
 			return FSlateIcon(FAppStyle::GetAppStyleSetName(), "Perforce.CheckedOutByOtherUser", NAME_None, "SourceControl.LockOverlay");
 		}
-		else if (IsModifiedInOtherBranch())
+
+		if (IsRetainedInOtherBranch())
+		{
+			return FSlateIcon(FAppStyle::GetAppStyleSetName(), "Perforce.CheckedOutByOtherUserOtherBranch", NAME_None, "SourceControl.LockOverlay");
+		}
+
+		if (IsModifiedInOtherBranch())
 		{
 			return FSlateIcon(FAppStyle::GetAppStyleSetName(), "Perforce.ModifiedOtherBranch");
 		}
@@ -370,13 +397,20 @@ FText FPlasticSourceControlState::GetDisplayName() const
 		return FText::Format(LOCTEXT("NotCurrent", "Not at the head revision CS:{0} {1} (local revision is CS:{2})"),
 			FText::AsNumber(DepotRevisionChangeset), FText::FromString(HeadUserName), FText::AsNumber(LocalRevisionChangeset, &NoCommas));
 	}
-	else if (!IsCheckedOutImplementation())
+
+	if (!IsCheckedOutImplementation())
 	{
 		if (IsCheckedOutOther())
 		{
-			return FText::Format(LOCTEXT("CheckedOutOther", "Checked out by {0} in {1}"), FText::FromString(LockedBy), FText::FromString(LockedWhere));
+			return FText::Format(LOCTEXT("CheckedOutOther", "Checked out by {0} on {1} (in {2})"), FText::FromString(LockedBy), FText::FromString(LockedBranch), FText::FromString(LockedWhere));
 		}
-		else if (IsModifiedInOtherBranch())
+
+		if (IsRetainedInOtherBranch())
+		{
+			return FText::Format(LOCTEXT("RetainedLock", "Retained on {0} by {1} (in {2})"), FText::FromString(LockedBranch), FText::FromString(RetainedBy), FText::FromString(LockedWhere));
+		}
+
+		if (IsModifiedInOtherBranch())
 		{
 			return FText::Format(LOCTEXT("ModifiedOtherBranch", "Modified in {0} as CS:{1} by {2} (local revision is CS:{3})"),
 				FText::FromString(HeadBranch), FText::AsNumber(HeadChangeList, &NoCommas), FText::FromString(HeadUserName), FText::AsNumber(LocalRevisionChangeset, &NoCommas));
@@ -431,13 +465,20 @@ FText FPlasticSourceControlState::GetDisplayTooltip() const
 		return FText::Format(LOCTEXT("NotCurrent_Tooltip", "Not at the head revision CS:{0} {1} (local revision is CS:{2})"),
 			FText::AsNumber(DepotRevisionChangeset), FText::FromString(HeadUserName), FText::AsNumber(LocalRevisionChangeset, &NoCommas));
 	}
-	else if (!IsCheckedOutImplementation())
+
+	if (!IsCheckedOutImplementation())
 	{
 		if (IsCheckedOutOther())
 		{
-			return FText::Format(LOCTEXT("CheckedOutOther_Tooltip", "Checked out by {0} in {1}"), FText::FromString(LockedBy), FText::FromString(LockedWhere));
+			return FText::Format(LOCTEXT("CheckedOutOther_Tooltip", "Checked out by {0} on {1} (in {2})"), FText::FromString(LockedBy), FText::FromString(LockedBranch), FText::FromString(LockedWhere));
 		}
-		else if (IsModifiedInOtherBranch())
+
+		if (IsRetainedInOtherBranch())
+		{
+			return FText::Format(LOCTEXT("RetainedLock_Tooltip", "Retained on {0} by {1} (in {2})"), FText::FromString(LockedBranch), FText::FromString(RetainedBy), FText::FromString(LockedWhere));
+		}
+
+		if (IsModifiedInOtherBranch())
 		{
 			return FText::Format(LOCTEXT("ModifiedOtherBranch_Tooltip", "Modified in {0} as CS:{1} by {2} (local revision is CS:{3})"),
 				FText::FromString(HeadBranch), FText::AsNumber(HeadChangeList, &NoCommas), FText::FromString(HeadUserName), FText::AsNumber(LocalRevisionChangeset, &NoCommas));
@@ -584,6 +625,11 @@ bool FPlasticSourceControlState::IsCheckedOutImplementation() const
 bool FPlasticSourceControlState::IsLocked() const
 {
 	return !LockedBy.IsEmpty();
+}
+
+bool FPlasticSourceControlState::IsRetainedInOtherBranch() const
+{
+	return !RetainedBy.IsEmpty();
 }
 
 bool FPlasticSourceControlState::IsCheckedOutOther(FString* Who) const

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
@@ -650,15 +650,15 @@ bool FPlasticSourceControlState::IsCheckedOutOther(FString* Who) const
 	return bIsLockedByOther;
 }
 
-/** Get whether this file is checked out in a different branch, if no branch is specified defaults to FEngineVerion current branch */
+/** Get whether this file is checked out in a different branch */
 bool FPlasticSourceControlState::IsCheckedOutInOtherBranch(const FString& CurrentBranch /* = FString() */) const
 {
-	// Note: to my knowledge, it's not possible to detect that with Unity Version Control without the Locks,
-	// which are already detected by fileinfo LockedBy/LockedWhere and reported by IsCheckedOutOther() above
-	return false;
+	// NOTE: technically this scenario isn't currently possible with Unity Version Control,
+	//       but the plugin need to use an existing Engine hook, so it's using this one as a way to display "Retained" locks
+	return IsRetainedInOtherBranch();
 }
 
-/** Get whether this file is modified in a different branch, if no branch is specified defaults to FEngineVerion current branch */
+/** Get whether this file is modified in a different branch */
 bool FPlasticSourceControlState::IsModifiedInOtherBranch(const FString& CurrentBranch /* = FString() */) const
 {
 	return !HeadBranch.IsEmpty();

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
@@ -79,6 +79,8 @@ public:
 		{
 			LockedBy = MoveTemp(InState.LockedBy);
 			LockedWhere = MoveTemp(InState.LockedWhere);
+			LockedBranch = MoveTemp(InState.LockedBranch);
+			RetainedBy = MoveTemp(InState.RetainedBy);
 			RepSpec = MoveTemp(InState.RepSpec);
 			DepotRevisionChangeset = InState.DepotRevisionChangeset;
 			LocalRevisionChangeset = InState.LocalRevisionChangeset;
@@ -180,8 +182,14 @@ public:
 	/** If a user (another or ourself) has this file locked, this contains their name. */
 	FString LockedBy;
 
-	/** Location of the locked file. */
+	/** Location (Workspace) where the file was exclusively checked-out. */
 	FString LockedWhere;
+
+	/** Branch where the filed was Locked or is Retained. */
+	FString LockedBranch;
+
+	/** If a user (another or ourself) has this file Retained on another branch, this contains their name. */
+	FString RetainedBy;
 
 	/** State of the workspace */
 	EWorkspaceState WorkspaceState = EWorkspaceState::Unknown;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
@@ -151,6 +151,7 @@ public:
 
 	bool IsCheckedOutImplementation() const;
 	bool IsLocked() const;
+	bool IsRetainedInOtherBranch() const;
 
 public:
 	/** History of the item, if any */

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -720,13 +720,12 @@ public:
 };
 
 
-static bool RunListSmartLocks(TMap<FString, FSmartLockInfoParser>& InOutSmartLocks)
+static bool RunListSmartLocks(const FPlasticSourceControlProvider& InProvider, TMap<FString, FSmartLockInfoParser>& InOutSmartLocks)
 {
 	TRACE_CPUPROFILER_EVENT_SCOPE(PlasticSourceControlUtils::RunListSmartLocks);
 
-	const FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
-	const FString& Repository = Provider.GetRepositoryName();
-	const FString& ServerUrl = Provider.GetServerUrl();
+	const FString& Repository = InProvider.GetRepositoryName();
+	const FString& ServerUrl = InProvider.GetServerUrl();
 
 	TArray<FString> Results;
 	TArray<FString> ErrorMessages;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -764,13 +764,14 @@ public:
 	{
 		TArray<FString> Fileinfos;
 		InResult.ParseIntoArray(Fileinfos, TEXT(";"), false); // Don't cull empty values in csv
-		if (Fileinfos.Num() == 5)
+		if (Fileinfos.Num() == 6)
 		{
 			RevisionChangeset = FCString::Atoi(*Fileinfos[0]);
 			RevisionHeadChangeset = FCString::Atoi(*Fileinfos[1]);
 			RepSpec = MoveTemp(Fileinfos[2]);
 			LockedBy = UserNameToDisplayName(MoveTemp(Fileinfos[3]));
 			LockedWhere = MoveTemp(Fileinfos[4]);
+			ServerPath = MoveTemp(Fileinfos[5]);
 		}
 	}
 
@@ -779,6 +780,7 @@ public:
 	FString RepSpec;
 	FString LockedBy;
 	FString LockedWhere;
+	FString ServerPath;
 };
 
 /** Parse the array of strings result of a 'cm fileinfo --format="{RevisionChangeset};{RevisionHeadChangeset};{RepSpec};{LockedBy};{LockedWhere}"' command
@@ -875,7 +877,7 @@ static bool RunFileinfo(const bool bInWholeDirectory, const bool bInUpdateHistor
 		TArray<FString> Results;
 		TArray<FString> ErrorMessages;
 		TArray<FString> Parameters;
-		Parameters.Add(TEXT("--format=\"{RevisionChangeset};{RevisionHeadChangeset};{RepSpec};{LockedBy};{LockedWhere}\""));
+		Parameters.Add(TEXT("--format=\"{RevisionChangeset};{RevisionHeadChangeset};{RepSpec};{LockedBy};{LockedWhere};{ServerPath}\""));
 		bResult = RunCommand(TEXT("fileinfo"), Parameters, SelectedFiles, Results, ErrorMessages);
 		OutErrorMessages.Append(MoveTemp(ErrorMessages));
 		if (bResult)
@@ -1151,7 +1153,7 @@ bool RunUpdateStatus(const TArray<FString>& InFiles, const EStatusSearchType InS
 		else if (States.Num() > 0)
 		{
 			// Run a "fileinfo" command to update complementary status information of given files.
-			// (ie RevisionChangeset, RevisionHeadChangeset, RepSpec, LockedBy, LockedWhere)
+			// (ie RevisionChangeset, RevisionHeadChangeset, RepSpec, LockedBy, LockedWhere, ServerPath)
 			// In case of "whole directory status", there is no explicit file in the group (it contains only the directory)
 			// => work on the list of files discovered by RunStatus()
 			bResults &= RunFileinfo(bWholeDirectory, bInUpdateHistory, OutErrorMessages, States);

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlVersions.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlVersions.h
@@ -38,4 +38,8 @@ namespace PlasticSourceControlVersions
 	// https://plasticscm.com/download/releasenotes/11.0.16.7709 (2023/01/12)
 	static const FSoftwareVersion StatusIsCheckedOutChanged(TEXT("11.0.16.7709"));
 
+	// 11.0.16.8101 Introducing Smart Locks (2023/07/06)
+	// https://www.plasticscm.com/download/releasenotes/11.0.16.8101
+	static const FSoftwareVersion SmartLocks(TEXT("11.0.16.8101"));
+
 } // namespace PlasticSourceControlVersions


### PR DESCRIPTION
- Add version 11.0.16.8101 as the one Introducing Smart Locks (2023/07/06)
- Implementation of RunListSmartLocks() and the associated FSmartLockInfoParser
- Update RunFileinfo() and FPlasticFileinfoParser to fetch the ServerPath
- Call the new RunListSmartLocks() from ParseFileinfoResults() and use it for SmartLocks information
- New IsRetainedInOtherBranch() used to display "Retained" locks overlay Icon and Tooltip
- Hack IsCheckedOutInOtherBranch() to work as IsRetainedInOtherBranch()
