### PR TITLE
Context Admin menu to Release or Remove a Lock from the Content Browser

### DIFF
--- a/Source/PlasticSourceControl/PlasticSourceControl.Build.cs
+++ b/Source/PlasticSourceControl/PlasticSourceControl.Build.cs
@@ -24,13 +24,9 @@ public class PlasticSourceControl : ModuleRules
 				"Projects",
 				"AssetRegistry",
 				"DeveloperSettings",
+				"ToolMenus",
 				"ContentBrowser",
 			}
 		);
-
-		if (Target.Version.MajorVersion == 5)
-		{
-			PrivateDependencyModuleNames.Add("ToolMenus");
-		}
 	}
 }

--- a/Source/PlasticSourceControl/PlasticSourceControl.Build.cs
+++ b/Source/PlasticSourceControl/PlasticSourceControl.Build.cs
@@ -24,6 +24,7 @@ public class PlasticSourceControl : ModuleRules
 				"Projects",
 				"AssetRegistry",
 				"DeveloperSettings",
+				"ContentBrowser",
 			}
 		);
 

--- a/Source/PlasticSourceControl/Private/PackageUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PackageUtils.cpp
@@ -25,6 +25,23 @@ static UWorld* GetCurrentWorld()
 	return nullptr;
 }
 
+TArray<FString> AssetDateToFileNames(const TArray<FAssetData>& InAssetObjectPaths)
+{
+	TArray<FString> FileNames;
+	FileNames.Reserve(InAssetObjectPaths.Num());
+	for (const FAssetData& AssetObjectPath : InAssetObjectPaths)
+	{
+		//  Tries to find the package in memory if it is loaded, otherwise loads it
+		if (UPackage* Package = AssetObjectPath.GetPackage())
+		{
+			const FString PackageExtension = Package->ContainsMap() ? FPackageName::GetMapPackageExtension() : FPackageName::GetAssetPackageExtension();
+			FString PackageFilename = FPackageName::LongPackageNameToFilename(Package->GetName(), PackageExtension);
+			FileNames.Add(MoveTemp(PackageFilename));
+		}
+	}
+	return FileNames;
+}
+
 // Find the packages corresponding to the files, if they are loaded in memory (won't load them)
 // Note: Extracted from AssetViewUtils::SyncPathsFromSourceControl()
 static TArray<UPackage*> FileNamesToLoadedPackages(const TArray<FString>& InFiles)

--- a/Source/PlasticSourceControl/Private/PackageUtils.h
+++ b/Source/PlasticSourceControl/Private/PackageUtils.h
@@ -6,6 +6,7 @@
 
 namespace PackageUtils
 {
+	TArray<FString> AssetDateToFileNames(const TArray<FAssetData>& InAssetObjectPaths);
 	void UnlinkPackages(const TArray<FString>& InFiles);
 	void UnlinkPackagesInMainThread(const TArray<FString>& InFiles);
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
@@ -639,13 +639,9 @@ void FPlasticSourceControlMenu::AddMenuExtension(FToolMenuSection& Menu)
 		)
 	);
 
-	FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
-	const FString& ServerUrl = Provider.GetServerUrl();
-	const int32 CloudIndex = ServerUrl.Find(TEXT("@cloud"));
-	if (CloudIndex > INDEX_NONE)
+	FString OrganizationName = FPlasticSourceControlModule::Get().GetProvider().GetCloudOrganization();
+	if (!OrganizationName.IsEmpty())
 	{
-		const FString& OrganizationName = ServerUrl.Left(CloudIndex);
-
 		Menu.AddMenuEntry(
 #if ENGINE_MAJOR_VERSION == 5
 			"PlasticLockRulesURL",
@@ -658,7 +654,7 @@ void FPlasticSourceControlMenu::AddMenuExtension(FToolMenuSection& Menu)
 			FSlateIcon(FEditorStyle::GetStyleSetName(), "PropertyWindow.Locked"),
 #endif
 			FUIAction(
-				FExecuteAction::CreateRaw(this, &FPlasticSourceControlMenu::VisitLockRulesURLClicked, OrganizationName),
+				FExecuteAction::CreateRaw(this, &FPlasticSourceControlMenu::VisitLockRulesURLClicked, MoveTemp(OrganizationName)),
 				FCanExecuteAction()
 			)
 		);

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
@@ -225,7 +225,8 @@ bool FPlasticSourceControlMenu::CanReleaseLocks(TArray<FAssetData> InAssetObject
 	{
 		const FString AbsoluteFilename = FPaths::ConvertRelativePathToFull(File);
 		const auto State = FPlasticSourceControlModule::Get().GetProvider().GetStateInternal(AbsoluteFilename);
-		if (!State->LockedBy.IsEmpty())
+		// If exclusively Checked Out (Locked) the lock can be released coming back to it's potential underlying "Retained" status if changes where already checked in the branch
+		if (!State->LockedBy.IsEmpty() && State->LockedId != ISourceControlState::INVALID_REVISION)
 		{
 			return true;
 		}
@@ -242,6 +243,7 @@ bool FPlasticSourceControlMenu::CanRemoveLocks(TArray<FAssetData> InAssetObjectP
 	{
 		const FString AbsoluteFilename = FPaths::ConvertRelativePathToFull(File);
 		const auto State = FPlasticSourceControlModule::Get().GetProvider().GetStateInternal(AbsoluteFilename);
+		// If Locked or Retained, the lock can be removed, that is completely deleted in order to simply ignore the changes from the branch 
 		if (State->LockedId != ISourceControlState::INVALID_REVISION)
 		{
 			return true;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.h
@@ -44,6 +44,19 @@ private:
 	void AddMenuExtension(FToolMenuSection& Menu);
 #endif
 
+	/** Extends the main Revision Control menu from the toolbar at the bottom-right. */
+	void ExtendRevisionControlMenu();
+	/** Extends the content browser asset context menu with Admin revision control options. */
+	void ExtendAssetContextMenu();
+	/** Called to generate concert asset context menu. */
+	void GeneratePlasticAssetContextMenu(FMenuBuilder& MenuBuilder, TArray<FAssetData> InAssetObjectPaths);
+
+	bool CanRemoveLocks(TArray<FAssetData> InAssetObjectPaths) const;
+	bool CanReleaseLocks(TArray<FAssetData> InAssetObjectPaths) const;
+	void ExecuteRemoveLocks(TArray<FAssetData> InAssetObjectPaths);
+	void ExecuteReleaseLocks(TArray<FAssetData> InAssetObjectPaths);
+	void ExecuteUnlock(const TArray<FAssetData>& InAssetObjectPaths, const bool bInRemove);
+
 	void DisplayInProgressNotification(const FText& InOperationInProgressString);
 	void RemoveInProgressNotification();
 	void DisplaySucessNotification(const FName& InOperationName);
@@ -59,6 +72,11 @@ private:
 
 	/** Current source control operation from extended menu if any */
 	TWeakPtr<class SNotificationItem> OperationInProgressNotification;
+
+	/** Name of the menu extension going into the global Revision Control (on the toolbar at the bottom-right) */
+	static FName UnityVersionControlMainMenuOwnerName;
+	/** Name of the asset context menu extension for admin actions over Locks */
+	static FName UnityVersionControlAssetContextLocksMenuOwnerName;
 
 	/** Delegate called when a source control operation has completed */
 	void OnSourceControlOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlModule.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlModule.h
@@ -33,11 +33,19 @@ public:
 	 * Singleton-like access to this module's interface.  This is just for convenience!
 	 * Beware of calling this during the shutdown phase, though.  Your module might have been unloaded already.
 	 *
-	 * @return Returns singleton instance, loading the module on demand if needed
+	 * @return Returns singleton instance, asserts if the module is not loaded yet or unloaded already.
 	 */
 	static inline FPlasticSourceControlModule& Get()
 	{
 		return FModuleManager::GetModuleChecked<FPlasticSourceControlModule>("PlasticSourceControl");
+	}
+
+	/**
+	 * Checks whether the module is currently loaded.
+	 */
+	static inline bool IsLoaded()
+	{
+		return FModuleManager::Get().IsModuleLoaded("PlasticSourceControl");
 	}
 
 private:

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
@@ -81,7 +81,7 @@ public:
 	FString WorkspaceName;
 	FString RepositoryName;
 	FString ServerUrl;
-	bool bPartialWorkspace;
+	bool bPartialWorkspace = false;
 };
 
 
@@ -95,6 +95,22 @@ public:
 	virtual FName GetName() const override;
 
 	virtual FText GetInProgressString() const override;
+};
+
+
+/**
+ * Internal operation used to release or remove Lock(s) on file(s)
+*/
+class FPlasticUnlock final : public ISourceControlOperation
+{
+public:
+	// ISourceControlOperation interface
+	virtual FName GetName() const override;
+
+	virtual FText GetInProgressString() const override;
+
+	// Release the Lock(s), and optionally remove (delete) them completely
+	bool bRemove = false;
 };
 
 
@@ -293,6 +309,24 @@ public:
 		: IPlasticSourceControlWorker(InSourceControlProvider)
 	{}
 	virtual ~FPlasticSwitchToPartialWorkspaceWorker() = default;
+	// IPlasticSourceControlWorker interface
+	virtual FName GetName() const override;
+	virtual bool Execute(class FPlasticSourceControlCommand& InCommand) override;
+	virtual bool UpdateStates() override;
+
+public:
+	/** Temporary states for results */
+	TArray<FPlasticSourceControlState> States;
+};
+
+/** release or remove Lock(s) on file(s). */
+class FPlasticUnlockWorker final : public IPlasticSourceControlWorker
+{
+public:
+	explicit FPlasticUnlockWorker(FPlasticSourceControlProvider& InSourceControlProvider)
+		: IPlasticSourceControlWorker(InSourceControlProvider)
+	{}
+	virtual ~FPlasticUnlockWorker() = default;
 	// IPlasticSourceControlWorker interface
 	virtual FName GetName() const override;
 	virtual bool Execute(class FPlasticSourceControlCommand& InCommand) override;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
@@ -310,6 +310,17 @@ const FName& FPlasticSourceControlProvider::GetName(void) const
 	return ProviderName;
 }
 
+FString FPlasticSourceControlProvider::GetCloudOrganization() const
+{
+	const int32 CloudIndex = ServerUrl.Find(TEXT("@cloud"));
+	if (CloudIndex > INDEX_NONE)
+	{
+		return ServerUrl.Left(CloudIndex);
+	}
+
+	return FString();
+}
+
 void FPlasticSourceControlProvider::SetLastErrors(const TArray<FString>& InErrors)
 {
 	FScopeLock Lock(&LastErrorsCriticalSection);

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.h
@@ -115,7 +115,7 @@ public:
 		return RepositoryName;
 	}
 
-	/** Get the Plastic current server URL */
+	/** Get the Plastic current server URL. See also GetCloudOrganization() */
 	inline const FString& GetServerUrl() const
 	{
 		return ServerUrl;
@@ -150,6 +150,9 @@ public:
 	{
 		return PluginVersion;
 	}
+
+	/** Return the name of the cloud organization from the ServerUrl if applicable (MyOrganization@cloud) or an empty string */
+	FString GetCloudOrganization() const;
 
 	/** Set list of error messages that occurred after last Plastic command */
 	void SetLastErrors(const TArray<FString>& InErrors);

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
@@ -402,12 +402,12 @@ FText FPlasticSourceControlState::GetDisplayName() const
 	{
 		if (IsCheckedOutOther())
 		{
-			return FText::Format(LOCTEXT("CheckedOutOther", "Checked out by {0} on {1} (in {2})"), FText::FromString(LockedBy), FText::FromString(LockedBranch), FText::FromString(LockedWhere));
+			return FText::Format(LOCTEXT("CheckedOutOther", "Checked out by {0} on {1} (in {2}) since {3}"), FText::FromString(LockedBy), FText::FromString(LockedBranch), FText::FromString(LockedWhere), FText::AsDateTime(LockedDate));
 		}
 
 		if (IsRetainedInOtherBranch())
 		{
-			return FText::Format(LOCTEXT("RetainedLock", "Retained on {0} by {1} (in {2})"), FText::FromString(LockedBranch), FText::FromString(RetainedBy), FText::FromString(LockedWhere));
+			return FText::Format(LOCTEXT("RetainedLock", "Retained on {0} by {1} since {2}"), FText::FromString(LockedBranch), FText::FromString(RetainedBy), FText::AsDateTime(LockedDate));
 		}
 
 		if (IsModifiedInOtherBranch())
@@ -470,12 +470,12 @@ FText FPlasticSourceControlState::GetDisplayTooltip() const
 	{
 		if (IsCheckedOutOther())
 		{
-			return FText::Format(LOCTEXT("CheckedOutOther_Tooltip", "Checked out by {0} on {1} (in {2})"), FText::FromString(LockedBy), FText::FromString(LockedBranch), FText::FromString(LockedWhere));
+			return FText::Format(LOCTEXT("CheckedOutOther_Tooltip", "Checked out by {0} on {1} (in {2}) since {3}"), FText::FromString(LockedBy), FText::FromString(LockedBranch), FText::FromString(LockedWhere), FText::AsDateTime(LockedDate));
 		}
 
 		if (IsRetainedInOtherBranch())
 		{
-			return FText::Format(LOCTEXT("RetainedLock_Tooltip", "Retained on {0} by {1} (in {2})"), FText::FromString(LockedBranch), FText::FromString(RetainedBy), FText::FromString(LockedWhere));
+			return FText::Format(LOCTEXT("RetainedLock_Tooltip", "Retained on {0} by {1} since {2}"), FText::FromString(LockedBranch), FText::FromString(RetainedBy), FText::AsDateTime(LockedDate));
 		}
 
 		if (IsModifiedInOtherBranch())

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
@@ -80,6 +80,8 @@ public:
 			LockedBy = MoveTemp(InState.LockedBy);
 			LockedWhere = MoveTemp(InState.LockedWhere);
 			LockedBranch = MoveTemp(InState.LockedBranch);
+			LockedId = MoveTemp(InState.LockedId);
+			LockedDate = MoveTemp(InState.LockedDate);
 			RetainedBy = MoveTemp(InState.RetainedBy);
 			RepSpec = MoveTemp(InState.RepSpec);
 			DepotRevisionChangeset = InState.DepotRevisionChangeset;
@@ -186,8 +188,14 @@ public:
 	/** Location (Workspace) where the file was exclusively checked-out. */
 	FString LockedWhere;
 
-	/** Branch where the filed was Locked or is Retained. */
+	/** Branch where the file was Locked or is Retained. */
 	FString LockedBranch;
+
+	/** Item id of the locked file (for an admin to unlock it). */
+	int32 LockedId = INVALID_REVISION;
+
+	/** Date when the file was Locked. */
+	FDateTime LockedDate = 0;
 
 	/** If a user (another or ourself) has this file Retained on another branch, this contains their name. */
 	FString RetainedBy;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -702,6 +702,8 @@ public:
 		if (NbElmts >= 12)
 		{
 			Repository = MoveTemp(SmartLockInfos[0]);
+			ItemId = FCString::Atoi(*SmartLockInfos[1]);
+			FDateTime::ParseIso8601(*SmartLockInfos[3], Date);
 			BranchName = MoveTemp(SmartLockInfos[6]);
 			Status = MoveTemp(SmartLockInfos[8]);
 			Owner = UserNameToDisplayName(MoveTemp(SmartLockInfos[9]));
@@ -710,6 +712,8 @@ public:
 	}
 
 	FString Repository;
+	int32 ItemId;
+	FDateTime Date;
 	FString BranchName;
 	FString Status;
 	FString Owner;
@@ -729,6 +733,7 @@ static bool RunListSmartLocks(const FString& InRepository, TMap<FString, FSmartL
 	Parameters.Add(TEXT("--smartlocks"));
 	Parameters.Add(TEXT("--anystatus"));
 	Parameters.Add(TEXT("--fieldseparator=\"") FILE_STATUS_SEPARATOR TEXT("\""));
+	Parameters.Add(TEXT("--dateformat=yyyy-MM-ddTHH:mm:ss"));
 	bool bResult = RunCommand(TEXT("lock"), Parameters, TArray<FString>(), Results, ErrorMessages);
 
 	if (bResult)
@@ -824,6 +829,8 @@ static void ParseFileinfoResults(const TArray<FString>& InResults, TArray<FPlast
 			}
 
 			FileState.LockedBranch = MoveTemp(SmartLock->BranchName);
+			FileState.LockedId = SmartLock->ItemId;
+			FileState.LockedDate = SmartLock->Date;
 		}
 
 		// debug log (only for the first few files)


### PR DESCRIPTION
- Simplification of RunListSmartLocks() and cleanup of variables
- FSmartLockInfoParser now also retrieve the Lock's ItemId and Date in order to unlock them
- Implement a new helper FPlasticSourceControlModule::IsLoaded()
- Implement a new PackageUtils AssetDateToFileNames()
- Add the Unlock Operation and associated Worker to Release or Remove Locks
- Implement a new FPlasticSourceControlProvider::GetCloudOrganization() to use it in multiple places in the Menu
- Release/Remove Locks from a new asset context admin submenu
- Adjusted UI implementation for UE4.27 and UE5.0 as the UI menu system was slightly different in before UE5.1 (no SelectedAssets in Context)
