### PR TITLE
Fix ongoing workspace creation shouldn't be interrupted if the users close the window too early

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
@@ -243,7 +243,7 @@ bool FPlasticSourceControlMenu::CanRemoveLocks(TArray<FAssetData> InAssetObjectP
 	{
 		const FString AbsoluteFilename = FPaths::ConvertRelativePathToFull(File);
 		const auto State = FPlasticSourceControlModule::Get().GetProvider().GetStateInternal(AbsoluteFilename);
-		// If Locked or Retained, the lock can be removed, that is completely deleted in order to simply ignore the changes from the branch 
+		// If Locked or Retained, the lock can be removed, that is completely deleted in order to simply ignore the changes from the branch
 		if (State->LockedId != ISourceControlState::INVALID_REVISION)
 		{
 			return true;
@@ -345,7 +345,7 @@ void FPlasticSourceControlMenu::SyncProjectClicked()
 			// Launch a custom "SyncAll" operation
 			FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
 			TSharedRef<FPlasticSyncAll, ESPMode::ThreadSafe> SyncOperation = ISourceControlOperation::Create<FPlasticSyncAll>();
-			const ECommandResult::Type Result = Provider.Execute(SyncOperation, TArray<FString>(), EConcurrency::Asynchronous, FSourceControlOperationComplete::CreateRaw(this, &FPlasticSourceControlMenu::OnSourceControlOperationComplete));
+			const ECommandResult::Type Result = Provider.Execute(SyncOperation, TArray<FString>(), EConcurrency::Asynchronous, FSourceControlOperationComplete::CreateRaw(this, &FPlasticSourceControlMenu::OnSyncAllOperationComplete));
 			if (Result == ECommandResult::Succeeded)
 			{
 				// Display an ongoing notification during the whole operation (packages will be reloaded at the completion of the operation)
@@ -417,7 +417,7 @@ void FPlasticSourceControlMenu::RevertAllClicked()
 				// Launch a "RevertAll" Operation
 				FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
 				TSharedRef<FPlasticRevertAll, ESPMode::ThreadSafe> RevertAllOperation = ISourceControlOperation::Create<FPlasticRevertAll>();
-				const ECommandResult::Type Result = Provider.Execute(RevertAllOperation, TArray<FString>(), EConcurrency::Asynchronous, FSourceControlOperationComplete::CreateRaw(this, &FPlasticSourceControlMenu::OnSourceControlOperationComplete));
+				const ECommandResult::Type Result = Provider.Execute(RevertAllOperation, TArray<FString>(), EConcurrency::Asynchronous, FSourceControlOperationComplete::CreateRaw(this, &FPlasticSourceControlMenu::OnRevertAllOperationComplete));
 				if (Result == ECommandResult::Succeeded)
 				{
 					// Display an ongoing notification during the whole operation
@@ -624,22 +624,27 @@ void FPlasticSourceControlMenu::DisplayFailureNotification(const FName& InOperat
 	UE_LOG(LogSourceControl, Error, TEXT("%s"), *NotificationText.ToString());
 }
 
+void FPlasticSourceControlMenu::OnSyncAllOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult)
+{
+	OnSourceControlOperationComplete(InOperation, InResult);
+
+	// Reload packages that where updated by the Sync operation (and the current map if needed)
+	TSharedRef<FPlasticSyncAll, ESPMode::ThreadSafe> Operation = StaticCastSharedRef<FPlasticSyncAll>(InOperation);
+	PackageUtils::ReloadPackages(Operation->UpdatedFiles);
+}
+
+void FPlasticSourceControlMenu::OnRevertAllOperationComplete(const FSourceControlOperationRef & InOperation, ECommandResult::Type InResult)
+{
+	OnSourceControlOperationComplete(InOperation, InResult);
+
+	// Reload packages that where updated by the Revert operation (and the current map if needed)
+	TSharedRef<FPlasticRevertAll, ESPMode::ThreadSafe> Operation = StaticCastSharedRef<FPlasticRevertAll>(InOperation);
+	PackageUtils::ReloadPackages(Operation->UpdatedFiles);
+}
+
 void FPlasticSourceControlMenu::OnSourceControlOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult)
 {
 	RemoveInProgressNotification();
-
-	if (InOperation->GetName() == "SyncAll")
-	{
-		// Reload packages that where updated by the Sync operation (and the current map if needed)
-		TSharedRef<FPlasticSyncAll, ESPMode::ThreadSafe> Operation = StaticCastSharedRef<FPlasticSyncAll>(InOperation);
-		PackageUtils::ReloadPackages(Operation->UpdatedFiles);
-	}
-	else if (InOperation->GetName() == "RevertAll")
-	{
-		// Reload packages that where updated by the Revert operation (and the current map if needed)
-		TSharedRef<FPlasticRevertAll, ESPMode::ThreadSafe> Operation = StaticCastSharedRef<FPlasticRevertAll>(InOperation);
-		PackageUtils::ReloadPackages(Operation->UpdatedFiles);
-	}
 
 	// Report result with a notification
 	if (InResult == ECommandResult::Succeeded)

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.h
@@ -78,6 +78,9 @@ private:
 	/** Name of the asset context menu extension for admin actions over Locks */
 	static FName UnityVersionControlAssetContextLocksMenuOwnerName;
 
-	/** Delegate called when a source control operation has completed */
+	/** Delegates called when a source control operation has completed */
+	void OnSyncAllOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
+	void OnRevertAllOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
+	/** Generic delegate and notification handler */
 	void OnSourceControlOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
 };

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlModule.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlModule.h
@@ -6,6 +6,7 @@
 #include "Modules/ModuleInterface.h"
 #include "Modules/ModuleManager.h"
 #include "PlasticSourceControlProvider.h"
+#include "PlasticSourceControlWorkspaceCreation.h"
 
 /**
  * PlasticSourceControl is the official Unity Version Control Plugin for Unreal Engine
@@ -27,6 +28,12 @@ public:
 	const FPlasticSourceControlProvider& GetProvider() const
 	{
 		return PlasticSourceControlProvider;
+	}
+
+	/** Access the controller to create a new workspace */
+	FPlasticSourceControlWorkspaceCreation& GetWorkspaceCreation()
+	{
+		return PlasticSourceControlWorkspaceCreation;
 	}
 
 	/**
@@ -51,4 +58,7 @@ public:
 private:
 	/** The Plastic source control provider */
 	FPlasticSourceControlProvider PlasticSourceControlProvider;
+
+	/** Logic to create a new workspace */
+	FPlasticSourceControlWorkspaceCreation PlasticSourceControlWorkspaceCreation;
 };

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -105,7 +105,7 @@ FName FPlasticMakeWorkspace::GetName() const
 
 FText FPlasticMakeWorkspace::GetInProgressString() const
 {
-	return LOCTEXT("SourceControl_MakeWorkspace", "Creating a new Repository and Workspace");
+	return LOCTEXT("SourceControl_MakeWorkspace", "Creating a new Repository and Workspace...");
 }
 
 FName FPlasticSwitchToPartialWorkspace::GetName() const
@@ -115,7 +115,7 @@ FName FPlasticSwitchToPartialWorkspace::GetName() const
 
 FText FPlasticSwitchToPartialWorkspace::GetInProgressString() const
 {
-	return LOCTEXT("SourceControl_SwitchToPartialWorkspace", "Switching to a Partial/Gluon Workspace");
+	return LOCTEXT("SourceControl_SwitchToPartialWorkspace", "Switching to a Partial/Gluon Workspace...");
 }
 
 FName FPlasticUnlock::GetName() const
@@ -126,9 +126,9 @@ FName FPlasticUnlock::GetName() const
 FText FPlasticUnlock::GetInProgressString() const
 {
 	if (bRemove)
-		return LOCTEXT("SourceControl_Unlock_Remove", "Removing Lock(s)");
+		return LOCTEXT("SourceControl_Unlock_Remove", "Removing Lock(s)...");
 	else
-		return LOCTEXT("SourceControl_Unlock_Release", "Releasing Lock(s)");
+		return LOCTEXT("SourceControl_Unlock_Release", "Releasing Lock(s)...");
 }
 
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlRevision.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlRevision.cpp
@@ -4,7 +4,6 @@
 #include "PlasticSourceControlModule.h"
 #include "PlasticSourceControlState.h"
 #include "PlasticSourceControlUtils.h"
-#include "SPlasticSourceControlSettings.h"
 
 #include "HAL/FileManager.h"
 #include "Misc/Paths.h"

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlRevision.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlRevision.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "ISourceControlRevision.h"
+#include "ISourceControlState.h"
 #include "Runtime/Launch/Resources/Version.h"
 
 class FPlasticSourceControlState;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlWorkspaceCreation.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlWorkspaceCreation.cpp
@@ -1,0 +1,209 @@
+// Copyright Unity Technologies
+
+#include "PlasticSourceControlWorkspaceCreation.h"
+
+#include "PlasticSourceControlOperations.h"
+#include "PlasticSourceControlModule.h"
+
+#include "SourceControlOperations.h"
+#include "ISourceControlModule.h"
+#include "Misc/Paths.h"
+#include "Framework/Notifications/NotificationManager.h"
+#include "Widgets/Notifications/SNotificationList.h"
+
+#define LOCTEXT_NAMESPACE "FPlasticSourceControlWorkspaceCreation"
+
+
+void FPlasticSourceControlWorkspaceCreation::MakeWorkspace(const FParameters& InParameters)
+{
+	WorkspaceParams = InParameters;
+
+	// 1.a. Create a repository (if not already existing) and a workspace: launch an asynchronous MakeWorkspace operation
+	LaunchMakeWorkspaceOperation();
+}
+
+/// 1. Create a repository (if not already existing) and a workspace
+void FPlasticSourceControlWorkspaceCreation::LaunchMakeWorkspaceOperation()
+{
+	TSharedRef<FPlasticMakeWorkspace, ESPMode::ThreadSafe> MakeWorkspaceOperation = ISourceControlOperation::Create<FPlasticMakeWorkspace>();
+	MakeWorkspaceOperation->WorkspaceName = WorkspaceParams.WorkspaceName.ToString();
+	MakeWorkspaceOperation->RepositoryName = WorkspaceParams.RepositoryName.ToString();
+	MakeWorkspaceOperation->ServerUrl = WorkspaceParams.ServerUrl.ToString();
+	MakeWorkspaceOperation->bPartialWorkspace = WorkspaceParams.bCreatePartialWorkspace;
+
+	FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
+	ECommandResult::Type Result = Provider.Execute(MakeWorkspaceOperation, TArray<FString>(), EConcurrency::Asynchronous, FSourceControlOperationComplete::CreateRaw(this, &FPlasticSourceControlWorkspaceCreation::OnMakeWorkspaceOperationComplete));
+	if (Result == ECommandResult::Succeeded)
+	{
+		DisplayInProgressNotification(MakeWorkspaceOperation->GetInProgressString());
+	}
+	else
+	{
+		DisplayFailureNotification(MakeWorkspaceOperation->GetName());
+	}
+}
+
+void FPlasticSourceControlWorkspaceCreation::OnMakeWorkspaceOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult)
+{
+	OnSourceControlOperationComplete(InOperation, InResult);
+
+	// Launch the next asynchronous operation
+	LaunchMarkForAddOperation();
+}
+
+/// 2. Add all project files to Source Control (.uproject, Config/, Content/, Source/ files and ignore.conf if any)
+void FPlasticSourceControlWorkspaceCreation::LaunchMarkForAddOperation()
+{
+	TSharedRef<FMarkForAdd, ESPMode::ThreadSafe> MarkForAddOperation = ISourceControlOperation::Create<FMarkForAdd>();
+	FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
+
+	// 1.b. Check the new workspace status to enable connection
+	Provider.CheckPlasticAvailability();
+
+	if (Provider.IsWorkspaceFound())
+	{
+		// 2. Add all project files to Source Control (.uproject, Config/, Content/, Source/ files and ignore.conf if any)
+		const TArray<FString> ProjectFiles = GetProjectFiles();
+		ECommandResult::Type Result = Provider.Execute(MarkForAddOperation, ProjectFiles, EConcurrency::Asynchronous, FSourceControlOperationComplete::CreateRaw(this, &FPlasticSourceControlWorkspaceCreation::OnMarkForAddOperationComplete));
+		if (Result == ECommandResult::Succeeded)
+		{
+			DisplayInProgressNotification(MarkForAddOperation->GetInProgressString());
+		}
+		else
+		{
+			DisplayFailureNotification(MarkForAddOperation->GetName());
+		}
+	}
+	else
+	{
+		DisplayFailureNotification(MarkForAddOperation->GetName());
+	}
+}
+
+void FPlasticSourceControlWorkspaceCreation::OnMarkForAddOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult)
+{
+	OnSourceControlOperationComplete(InOperation, InResult);
+
+	// Launch the next asynchronous operation
+	LaunchCheckInOperation();
+}
+
+/// 3. Launch an asynchronous "CheckIn" operation and start another ongoing notification
+void FPlasticSourceControlWorkspaceCreation::LaunchCheckInOperation()
+{
+	TSharedRef<FCheckIn, ESPMode::ThreadSafe> CheckInOperation = ISourceControlOperation::Create<FCheckIn>();
+	CheckInOperation->SetDescription(WorkspaceParams.InitialCommitMessage);
+	FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
+	const TArray<FString> ProjectFiles = GetProjectFiles(); // Note: listing files and folders is only needed for the update status operation following the checkin to know on what to operate
+	ECommandResult::Type Result = Provider.Execute(CheckInOperation, ProjectFiles, EConcurrency::Asynchronous, FSourceControlOperationComplete::CreateRaw(this, &FPlasticSourceControlWorkspaceCreation::OnCheckInOperationComplete));
+	if (Result == ECommandResult::Succeeded)
+	{
+		DisplayInProgressNotification(CheckInOperation->GetInProgressString());
+	}
+	else
+	{
+		DisplayFailureNotification(CheckInOperation->GetName());
+	}
+}
+
+void FPlasticSourceControlWorkspaceCreation::OnCheckInOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult)
+{
+	OnSourceControlOperationComplete(InOperation, InResult);
+
+	// Note: no more operation to launch, the workspace is ready to use
+}
+
+void FPlasticSourceControlWorkspaceCreation::OnSourceControlOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult)
+{
+	RemoveInProgressNotification();
+
+	// Report result with a notification
+	if (InResult == ECommandResult::Succeeded)
+	{
+		DisplaySuccessNotification(InOperation->GetName());
+	}
+	else
+	{
+		DisplayFailureNotification(InOperation->GetName());
+	}
+}
+
+// Display an ongoing notification during the whole operation
+void FPlasticSourceControlWorkspaceCreation::DisplayInProgressNotification(const FText& InOperationInProgressString)
+{
+	if (!OperationInProgressNotification.IsValid())
+	{
+		FNotificationInfo Info(InOperationInProgressString);
+		Info.bFireAndForget = false;
+		Info.ExpireDuration = 0.0f;
+		Info.FadeOutDuration = 1.0f;
+		OperationInProgressNotification = FSlateNotificationManager::Get().AddNotification(Info);
+		if (OperationInProgressNotification.IsValid())
+		{
+			OperationInProgressNotification.Pin()->SetCompletionState(SNotificationItem::CS_Pending);
+		}
+	}
+}
+
+// Remove the ongoing notification at the end of the operation
+void FPlasticSourceControlWorkspaceCreation::RemoveInProgressNotification()
+{
+	if (OperationInProgressNotification.IsValid())
+	{
+		OperationInProgressNotification.Pin()->ExpireAndFadeout();
+		OperationInProgressNotification.Reset();
+	}
+}
+
+// Display a temporary success notification at the end of the operation
+void FPlasticSourceControlWorkspaceCreation::DisplaySuccessNotification(const FName& InOperationName)
+{
+	const FText NotificationText = FText::Format(LOCTEXT("InitWorkspace_Success", "{0} operation was successful!"), FText::FromName(InOperationName));
+	FNotificationInfo Info(NotificationText);
+	Info.bUseSuccessFailIcons = true;
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
+	Info.Image = FAppStyle::GetBrush(TEXT("NotificationList.SuccessImage"));
+#else
+	Info.Image = FEditorStyle::GetBrush(TEXT("NotificationList.SuccessImage"));
+#endif
+	FSlateNotificationManager::Get().AddNotification(Info);
+	UE_LOG(LogSourceControl, Verbose, TEXT("%s"), *NotificationText.ToString());
+}
+
+// Display a temporary failure notification at the end of the operation
+void FPlasticSourceControlWorkspaceCreation::DisplayFailureNotification(const FName& InOperationName)
+{
+	const FText NotificationText = FText::Format(LOCTEXT("InitWorkspace_Failure", "Error: {0} operation failed!"), FText::FromName(InOperationName));
+	FNotificationInfo Info(NotificationText);
+	Info.ExpireDuration = 8.0f;
+	FSlateNotificationManager::Get().AddNotification(Info);
+	UE_LOG(LogSourceControl, Error, TEXT("%s"), *NotificationText.ToString());
+}
+
+/** Path to the "ignore.conf" file */
+const FString FPlasticSourceControlWorkspaceCreation::GetIgnoreFileName() const
+{
+	const FString PathToWorkspaceRoot = FPlasticSourceControlModule::Get().GetProvider().GetPathToWorkspaceRoot();
+	const FString IgnoreFileName = FPaths::Combine(*PathToWorkspaceRoot, TEXT("ignore.conf"));
+	return IgnoreFileName;
+}
+
+/** List of files to add to Source Control (.uproject, Config/, Content/, Source/ files and ignore.conf if any) */
+TArray<FString> FPlasticSourceControlWorkspaceCreation::GetProjectFiles() const
+{
+	TArray<FString> ProjectFiles;
+	ProjectFiles.Add(FPaths::ConvertRelativePathToFull(FPaths::GetProjectFilePath()));
+	ProjectFiles.Add(FPaths::ConvertRelativePathToFull(FPaths::ProjectConfigDir()));
+	ProjectFiles.Add(FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()));
+	if (FPaths::DirectoryExists(FPaths::GameSourceDir()))
+	{
+		ProjectFiles.Add(FPaths::ConvertRelativePathToFull(FPaths::GameSourceDir()));
+	}
+	if (FPaths::FileExists(GetIgnoreFileName()))
+	{
+		ProjectFiles.Add(GetIgnoreFileName());
+	}
+	return ProjectFiles;
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlWorkspaceCreation.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlWorkspaceCreation.h
@@ -1,0 +1,50 @@
+// Copyright Unity Technologies
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+#include "ISourceControlProvider.h"
+#include "ISourceControlOperation.h"
+
+class FPlasticSourceControlWorkspaceCreation
+{
+public:
+	struct FParameters
+	{
+		FText WorkspaceName;
+		FText RepositoryName;
+		FText ServerUrl;
+		bool bCreatePartialWorkspace = false;
+		bool bAutoInitialCommit = true;
+		FText InitialCommitMessage;
+	};
+
+	FParameters WorkspaceParams;
+
+	void MakeWorkspace(const FParameters& InParameters);
+
+private:
+	/** Launch initial asynchronous add and commit operations */
+	void LaunchMakeWorkspaceOperation();
+	void LaunchMarkForAddOperation();
+	void LaunchCheckInOperation();
+
+	/** Delegates called when a source control operation has completed */
+	void OnMakeWorkspaceOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
+	void OnMarkForAddOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
+	void OnCheckInOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
+	/** Generic notification handler */
+	void OnSourceControlOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
+
+	/** Asynchronous operation progress notifications */
+	TWeakPtr<class SNotificationItem> OperationInProgressNotification;
+
+	void DisplayInProgressNotification(const FText& InOperationInProgressString);
+	void RemoveInProgressNotification();
+	void DisplaySuccessNotification(const FName& InOperationName);
+	void DisplayFailureNotification(const FName& InOperationName);
+
+	const FString GetIgnoreFileName() const;
+	TArray<FString> GetProjectFiles() const;
+};

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.cpp
@@ -12,7 +12,6 @@
 #include "Misc/App.h"
 #include "Misc/FileHelper.h"
 #include "Modules/ModuleManager.h"
-#include "Framework/Notifications/NotificationManager.h"
 #include "Styling/SlateTypes.h"
 #include "Widgets/Input/SEditableTextBox.h"
 #include "Widgets/Input/SMultiLineEditableTextBox.h"
@@ -20,7 +19,6 @@
 #include "Widgets/Input/SCheckBox.h"
 #include "Widgets/Layout/SBorder.h"
 #include "Widgets/Layout/SSeparator.h"
-#include "Widgets/Notifications/SNotificationList.h"
 #include "Widgets/SBoxPanel.h"
 #include "Widgets/Text/STextBlock.h"
 #include "Runtime/Launch/Resources/Version.h"
@@ -547,174 +545,16 @@ FReply SPlasticSourceControlSettings::OnClickedCreatePlasticWorkspace()
 		*WorkspaceParams.WorkspaceName.ToString(), *WorkspaceParams.RepositoryName.ToString(), *WorkspaceParams.ServerUrl.ToString(),
 		WorkspaceParams.bCreatePartialWorkspace, bAutoCreateIgnoreFile, WorkspaceParams.bAutoInitialCommit);
 
-	// 1.a. Create a repository (if not already existing) and a workspace: launch an asynchronous MakeWorkspace operation
-	LaunchMakeWorkspaceOperation();
+	if (bAutoCreateIgnoreFile)
+	{
+		// 1. Create a standard "ignore.conf" file with common patterns for a typical Blueprint & C++ project
+		CreateIgnoreFile();
+	}
+
+	// 2. Create a repository (if not already existing) and a workspace: launch an asynchronous MakeWorkspace operation
+	FPlasticSourceControlModule::Get().GetWorkspaceCreation().MakeWorkspace(WorkspaceParams);
 
 	return FReply::Handled();
-}
-
-
-/// 1. Create a repository (if not already existing) and a workspace
-void SPlasticSourceControlSettings::LaunchMakeWorkspaceOperation()
-{
-	TSharedRef<FPlasticMakeWorkspace, ESPMode::ThreadSafe> MakeWorkspaceOperation = ISourceControlOperation::Create<FPlasticMakeWorkspace>();
-	MakeWorkspaceOperation->WorkspaceName = WorkspaceParams.WorkspaceName.ToString();
-	MakeWorkspaceOperation->RepositoryName = WorkspaceParams.RepositoryName.ToString();
-	MakeWorkspaceOperation->ServerUrl = WorkspaceParams.ServerUrl.ToString();
-	MakeWorkspaceOperation->bPartialWorkspace = WorkspaceParams.bCreatePartialWorkspace;
-
-	FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
-	ECommandResult::Type Result = Provider.Execute(MakeWorkspaceOperation, TArray<FString>(), EConcurrency::Asynchronous, FSourceControlOperationComplete::CreateSP(this, &SPlasticSourceControlSettings::OnMakeWorkspaceOperationComplete));
-	if (Result == ECommandResult::Succeeded)
-	{
-		DisplayInProgressNotification(MakeWorkspaceOperation->GetInProgressString());
-	}
-	else
-	{
-		DisplayFailureNotification(MakeWorkspaceOperation->GetName());
-	}
-}
-
-void SPlasticSourceControlSettings::OnMakeWorkspaceOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult)
-{
-	OnSourceControlOperationComplete(InOperation, InResult);
-
-	// Launch the following asynchronous operation
-	LaunchMarkForAddOperation();
-}
-
-/// 2. Add all project files to Source Control (.uproject, Config/, Content/, Source/ files and ignore.conf if any)
-void SPlasticSourceControlSettings::LaunchMarkForAddOperation()
-{
-	TSharedRef<FMarkForAdd, ESPMode::ThreadSafe> MarkForAddOperation = ISourceControlOperation::Create<FMarkForAdd>();
-	FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
-
-	// 1.b. Check the new workspace status to enable connection
-	Provider.CheckPlasticAvailability();
-
-	if (Provider.IsWorkspaceFound())
-	{
-		if (bAutoCreateIgnoreFile)
-		{
-			// 1.c Create a standard "ignore.conf" file with common patterns for a typical Blueprint & C++ project
-			CreateIgnoreFile();
-		}
-		// 2. Add all project files to Source Control (.uproject, Config/, Content/, Source/ files and ignore.conf if any)
-		const TArray<FString> ProjectFiles = GetProjectFiles();
-		ECommandResult::Type Result = Provider.Execute(MarkForAddOperation, ProjectFiles, EConcurrency::Asynchronous, FSourceControlOperationComplete::CreateSP(this, &SPlasticSourceControlSettings::OnMarkForAddOperationComplete));
-		if (Result == ECommandResult::Succeeded)
-		{
-			DisplayInProgressNotification(MarkForAddOperation->GetInProgressString());
-		}
-		else
-		{
-			DisplayFailureNotification(MarkForAddOperation->GetName());
-		}
-	}
-	else
-	{
-		DisplayFailureNotification(MarkForAddOperation->GetName());
-	}
-}
-
-void SPlasticSourceControlSettings::OnMarkForAddOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult)
-{
-	OnSourceControlOperationComplete(InOperation, InResult);
-
-	// Launch the following asynchronous operation
-	LaunchCheckInOperation();
-}
-
-/// 3. Launch an asynchronous "CheckIn" operation and start another ongoing notification
-void SPlasticSourceControlSettings::LaunchCheckInOperation()
-{
-	TSharedRef<FCheckIn, ESPMode::ThreadSafe> CheckInOperation = ISourceControlOperation::Create<FCheckIn>();
-	CheckInOperation->SetDescription(WorkspaceParams.InitialCommitMessage);
-	FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
-	const TArray<FString> ProjectFiles = GetProjectFiles(); // Note: listing files and folders is only needed for the update status operation following the checkin to know on what to operate
-	ECommandResult::Type Result = Provider.Execute(CheckInOperation, ProjectFiles, EConcurrency::Asynchronous, FSourceControlOperationComplete::CreateSP(this, &SPlasticSourceControlSettings::OnCheckInOperationComplete));
-	if (Result == ECommandResult::Succeeded)
-	{
-		DisplayInProgressNotification(CheckInOperation->GetInProgressString());
-	}
-	else
-	{
-		DisplayFailureNotification(CheckInOperation->GetName());
-	}
-}
-
-void SPlasticSourceControlSettings::OnCheckInOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult)
-{
-	OnSourceControlOperationComplete(InOperation, InResult);
-
-	// Note: no more operation to launch, the workspace is ready to use
-}
-
-void SPlasticSourceControlSettings::OnSourceControlOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult)
-{
-	RemoveInProgressNotification();
-
-	// Report result with a notification
-	if (InResult == ECommandResult::Succeeded)
-	{
-		DisplaySuccessNotification(InOperation->GetName());
-	}
-	else
-	{
-		DisplayFailureNotification(InOperation->GetName());
-	}
-}
-
-// Display an ongoing notification during the whole operation
-void SPlasticSourceControlSettings::DisplayInProgressNotification(const FText& InOperationInProgressString)
-{
-	if (!OperationInProgressNotification.IsValid())
-	{
-		FNotificationInfo Info(InOperationInProgressString);
-		Info.bFireAndForget = false;
-		Info.ExpireDuration = 0.0f;
-		Info.FadeOutDuration = 1.0f;
-		OperationInProgressNotification = FSlateNotificationManager::Get().AddNotification(Info);
-		if (OperationInProgressNotification.IsValid())
-		{
-			OperationInProgressNotification.Pin()->SetCompletionState(SNotificationItem::CS_Pending);
-		}
-	}
-}
-
-// Remove the ongoing notification at the end of the operation
-void SPlasticSourceControlSettings::RemoveInProgressNotification()
-{
-	if (OperationInProgressNotification.IsValid())
-	{
-		OperationInProgressNotification.Pin()->ExpireAndFadeout();
-		OperationInProgressNotification.Reset();
-	}
-}
-
-// Display a temporary success notification at the end of the operation
-void SPlasticSourceControlSettings::DisplaySuccessNotification(const FName& InOperationName)
-{
-	const FText NotificationText = FText::Format(LOCTEXT("InitWorkspace_Success", "{0} operation was successful!"), FText::FromName(InOperationName));
-	FNotificationInfo Info(NotificationText);
-	Info.bUseSuccessFailIcons = true;
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
-	Info.Image = FAppStyle::GetBrush(TEXT("NotificationList.SuccessImage"));
-#else
-	Info.Image = FEditorStyle::GetBrush(TEXT("NotificationList.SuccessImage"));
-#endif
-	FSlateNotificationManager::Get().AddNotification(Info);
-	UE_LOG(LogSourceControl, Verbose, TEXT("%s"), *NotificationText.ToString());
-}
-
-// Display a temporary failure notification at the end of the operation
-void SPlasticSourceControlSettings::DisplayFailureNotification(const FName& InOperationName)
-{
-	const FText NotificationText = FText::Format(LOCTEXT("InitWorkspace_Failure", "Error: {0} operation failed!"), FText::FromName(InOperationName));
-	FNotificationInfo Info(NotificationText);
-	Info.ExpireDuration = 8.0f;
-	FSlateNotificationManager::Get().AddNotification(Info);
-	UE_LOG(LogSourceControl, Error, TEXT("%s"), *NotificationText.ToString());
 }
 
 /** Delegate to check for presence of an ignore.conf file to an existing Unity Version Control workspace */
@@ -796,24 +636,6 @@ bool SPlasticSourceControlSettings::CreateIgnoreFile() const
 {
 	const FString IgnoreFileContent = TEXT("Binaries\nBuild\nDerivedDataCache\nIntermediate\nSaved\nScript\nenc_temp_folder\n.idea\n.vscode\n.vs\n.ignore\n*.VC.db\n*.opensdf\n*.opendb\n*.sdf\n*.sln\n*.suo\n*.code-workspace\n*.xcodeproj\n*.xcworkspace");
 	return FFileHelper::SaveStringToFile(IgnoreFileContent, *GetIgnoreFileName(), FFileHelper::EEncodingOptions::ForceUTF8WithoutBOM);
-}
-
-/** List of files to add to Source Control (.uproject, Config/, Content/, Source/ files and ignore.conf if any) */
-TArray<FString> SPlasticSourceControlSettings::GetProjectFiles() const
-{
-	TArray<FString> ProjectFiles;
-	ProjectFiles.Add(FPaths::ConvertRelativePathToFull(FPaths::GetProjectFilePath()));
-	ProjectFiles.Add(FPaths::ConvertRelativePathToFull(FPaths::ProjectConfigDir()));
-	ProjectFiles.Add(FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()));
-	if (FPaths::DirectoryExists(FPaths::GameSourceDir()))
-	{
-		ProjectFiles.Add(FPaths::ConvertRelativePathToFull(FPaths::GameSourceDir()));
-	}
-	if (FPaths::FileExists(GetIgnoreFileName()))
-	{
-		ProjectFiles.Add(GetIgnoreFileName());
-	}
-	return ProjectFiles;
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.h
@@ -41,16 +41,12 @@ private:
 	bool IsReadyToCreatePlasticWorkspace() const;
 	void OnWorkspaceNameCommited(const FText& InText, ETextCommit::Type InCommitType);
 	FText GetWorkspaceName() const;
-	FText WorkspaceName;
 	void OnRepositoryNameCommited(const FText& InText, ETextCommit::Type InCommitType);
 	FText GetRepositoryName() const;
-	FText RepositoryName;
 	void OnServerUrlCommited(const FText& InText, ETextCommit::Type InCommitType);
 	FText GetServerUrl() const;
-	FText ServerUrl;
 	bool CreatePartialWorkspace() const;
 	void OnCheckedCreatePartialWorkspace(ECheckBoxState NewCheckedState);
-	bool bCreatePartialWorkspace;
 	bool CanAutoCreateIgnoreFile() const;
 	void OnCheckedCreateIgnoreFile(ECheckBoxState NewCheckedState);
 	bool bAutoCreateIgnoreFile;
@@ -65,10 +61,20 @@ private:
 	ECheckBoxState IsEnableVerboseLogsChecked() const;
 
 	void OnCheckedInitialCommit(ECheckBoxState NewCheckedState);
-	bool bAutoInitialCommit;
 	void OnInitialCommitMessageCommited(const FText& InText, ETextCommit::Type InCommitType);
 	FText GetInitialCommitMessage() const;
-	FText InitialCommitMessage;
+
+	struct FPlasticWorkspaceCreationParameters
+	{
+		FText WorkspaceName;
+		FText RepositoryName;
+		FText ServerUrl;
+		bool bCreatePartialWorkspace = false;
+		bool bAutoInitialCommit = true;
+		FText InitialCommitMessage;
+	};
+
+	FPlasticWorkspaceCreationParameters WorkspaceParams;
 
 	/** Launch initial asynchronous add and commit operations */
 	void LaunchMakeWorkspaceOperation();

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.h
@@ -9,8 +9,7 @@
 #include "Input/Reply.h"
 #include "Styling/SlateTypes.h"
 
-#include "ISourceControlProvider.h"
-#include "ISourceControlOperation.h"
+#include "PlasticSourceControlWorkspaceCreation.h"
 
 class SPlasticSourceControlSettings : public SCompoundWidget
 {
@@ -64,39 +63,10 @@ private:
 	void OnInitialCommitMessageCommited(const FText& InText, ETextCommit::Type InCommitType);
 	FText GetInitialCommitMessage() const;
 
-	struct FPlasticWorkspaceCreationParameters
-	{
-		FText WorkspaceName;
-		FText RepositoryName;
-		FText ServerUrl;
-		bool bCreatePartialWorkspace = false;
-		bool bAutoInitialCommit = true;
-		FText InitialCommitMessage;
-	};
-
-	FPlasticWorkspaceCreationParameters WorkspaceParams;
-
-	/** Launch initial asynchronous add and commit operations */
-	void LaunchMakeWorkspaceOperation();
-	void LaunchMarkForAddOperation();
-	void LaunchCheckInOperation();
-
-	/** Delegates called when a source control operation has completed */
-	void OnMakeWorkspaceOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
-	void OnMarkForAddOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
-	void OnCheckInOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
-	/** Generic notification handler */
-	void OnSourceControlOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
-
-	/** Asynchronous operation progress notifications */
-	TWeakPtr<class SNotificationItem> OperationInProgressNotification;
-
-	void DisplayInProgressNotification(const FText& InOperationInProgressString);
-	void RemoveInProgressNotification();
-	void DisplaySuccessNotification(const FName& InOperationName);
-	void DisplayFailureNotification(const FName& InOperationName);
-
 	FReply OnClickedCreatePlasticWorkspace();
+
+	// Parameters for the workspace creation
+	FPlasticSourceControlWorkspaceCreation::FParameters WorkspaceParams;
 
 	/** Delegate to add a Plastic ignore.conf file to an existing Plastic workspace */
 	EVisibility CanAddIgnoreFile() const;
@@ -104,6 +74,4 @@ private:
 
 	const FString GetIgnoreFileName() const;
 	bool CreateIgnoreFile() const;
-
-	TArray<FString> GetProjectFiles() const;
 };

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.h
@@ -75,7 +75,11 @@ private:
 	void LaunchMarkForAddOperation();
 	void LaunchCheckInOperation();
 
-	/** Delegate called when a source control operation has completed */
+	/** Delegates called when a source control operation has completed */
+	void OnMakeWorkspaceOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
+	void OnMarkForAddOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
+	void OnCheckInOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
+	/** Generic notification handler */
 	void OnSourceControlOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
 
 	/** Asynchronous operation progress notifications */


### PR DESCRIPTION
- Split OnSourceControlOperationComplete() methods in dedicated delegates
- Move workspace creation parameters into a dedicated structure
- Move the workspace creation logic into a dedicated class: the instance is hold by the module, and kept alive when the Login window is closed (this is the actual fix)

![image](https://github.com/PlasticSCM/UEPlasticPlugin/assets/101874327/0e221706-8c02-4247-9a5e-07f24acc3257)
