### PR TITLE
Displaying the name of the current branch in the status bar

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
@@ -5,6 +5,7 @@
 #include "PlasticSourceControlModule.h"
 #include "PlasticSourceControlProvider.h"
 #include "PlasticSourceControlOperations.h"
+#include "SPlasticSourceControlStatusBar.h"
 
 #include "ISourceControlModule.h"
 #include "ISourceControlOperation.h"
@@ -37,6 +38,7 @@
 
 FName FPlasticSourceControlMenu::UnityVersionControlMainMenuOwnerName = TEXT("UnityVersionControlMenu");
 FName FPlasticSourceControlMenu::UnityVersionControlAssetContextLocksMenuOwnerName = TEXT("UnityVersionControlContextLocksMenu");
+FName FPlasticSourceControlMenu::UnityVersionControlStatusBarMenuOwnerName = TEXT("UnityVersionControlStatusBarMenu");
 
 void FPlasticSourceControlMenu::Register()
 {
@@ -48,6 +50,8 @@ void FPlasticSourceControlMenu::Register()
 	// Register the menu extensions with the level editor
 	ExtendRevisionControlMenu();
 	ExtendAssetContextMenu();
+
+	ExtendToolbarWithStatusBarWidget();
 }
 
 void FPlasticSourceControlMenu::Unregister()
@@ -73,11 +77,25 @@ void FPlasticSourceControlMenu::Unregister()
 	{
 		ToolMenus->UnregisterOwnerByName(UnityVersionControlMainMenuOwnerName);
 		ToolMenus->UnregisterOwnerByName(UnityVersionControlAssetContextLocksMenuOwnerName);
+		ToolMenus->UnregisterOwnerByName(UnityVersionControlStatusBarMenuOwnerName);
 		bHasRegistered = false;
 	}
 #endif
 }
 
+void FPlasticSourceControlMenu::ExtendToolbarWithStatusBarWidget()
+{
+#if ENGINE_MAJOR_VERSION == 5
+	const FToolMenuOwnerScoped SourceControlMenuOwner(UnityVersionControlStatusBarMenuOwnerName);
+
+	UToolMenu* ToolbarMenu = UToolMenus::Get()->ExtendMenu("LevelEditor.StatusBar.ToolBar");
+	FToolMenuSection& Section = ToolbarMenu->AddSection("Unity Version Control", FText::GetEmpty(), FToolMenuInsert("SourceControl", EToolMenuInsertType::Before));
+
+	Section.AddEntry(
+		FToolMenuEntry::InitWidget("UnityVersionControlStatusBar", SNew(SPlasticSourceControlStatusBar), FText::GetEmpty(), true, false)
+	);
+#endif
+}
 
 void FPlasticSourceControlMenu::ExtendRevisionControlMenu()
 {

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.h
@@ -44,6 +44,9 @@ private:
 	void AddMenuExtension(FToolMenuSection& Menu);
 #endif
 
+	/** Extends the UE5 toolbar with a status bar widget to display the current branch and open the branch tab */
+	void ExtendToolbarWithStatusBarWidget();
+
 	/** Extends the main Revision Control menu from the toolbar at the bottom-right. */
 	void ExtendRevisionControlMenu();
 	/** Extends the content browser asset context menu with Admin revision control options. */
@@ -77,6 +80,8 @@ private:
 	static FName UnityVersionControlMainMenuOwnerName;
 	/** Name of the asset context menu extension for admin actions over Locks */
 	static FName UnityVersionControlAssetContextLocksMenuOwnerName;
+	/** Name of status bar extension to display the current branch  */
+	static FName UnityVersionControlStatusBarMenuOwnerName;
 
 	/** Delegates called when a source control operation has completed */
 	void OnSyncAllOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlStatusBar.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlStatusBar.cpp
@@ -10,6 +10,7 @@
 #else
 #include "EditorStyleSet.h"
 #endif
+#include "Styling\SlateTypes.h"
 
 #define LOCTEXT_NAMESPACE "PlasticSourceControl"
 
@@ -20,7 +21,11 @@ void SPlasticSourceControlStatusBar::Construct(const FArguments& InArgs)
 		SNew(SButton)
 		.ContentPadding(FMargin(6.0f, 0.0f))
 		.ToolTipText(LOCTEXT("PlasticBranches_Tooltip", "Current branch"))
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
 		.ButtonStyle(FAppStyle::Get(), "SimpleButton")
+#else
+		.ButtonStyle(FEditorStyle::Get(), "SimpleButton")
+#endif
 		.OnClicked(this, &SPlasticSourceControlStatusBar::OnClicked)
 		[
 			SNew(SHorizontalBox)
@@ -29,7 +34,7 @@ void SPlasticSourceControlStatusBar::Construct(const FArguments& InArgs)
 			.VAlign(VAlign_Center)
 			.HAlign(HAlign_Center)
 			[
-				SNew(SImage)	
+				SNew(SImage)
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
 				.Image(FAppStyle::GetBrush("SourceControl.Branch"))
 #else
@@ -42,7 +47,11 @@ void SPlasticSourceControlStatusBar::Construct(const FArguments& InArgs)
 			.Padding(FMargin(5, 0, 0, 0))
 			[
 				SNew(STextBlock)
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
 				.TextStyle(&FAppStyle::Get().GetWidgetStyle<FTextBlockStyle>("NormalText"))
+#else
+				.TextStyle(&FEditorStyle::Get().GetWidgetStyle<FTextBlockStyle>("NormalText"))
+#endif
 				.Text_Lambda([this]() { return GetStatusBarText(); })
 			]
 		]

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlStatusBar.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlStatusBar.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2023 Unity Technologies
+
+#include "SPlasticSourceControlStatusBar.h"
+
+#include "PlasticSourceControlModule.h"
+
+#define LOCTEXT_NAMESPACE "PlasticSourceControl"
+
+void SPlasticSourceControlStatusBar::Construct(const FArguments& InArgs)
+{
+	ChildSlot
+	[
+		SNew(SButton)
+		.ContentPadding(FMargin(6.0f, 0.0f))
+		.ToolTipText(LOCTEXT("PlasticBranches_Tooltip", "Current branch"))
+		.ButtonStyle(FAppStyle::Get(), "SimpleButton")
+		.OnClicked(this, &SPlasticSourceControlStatusBar::OnClicked)
+		[
+			SNew(SHorizontalBox)
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			.VAlign(VAlign_Center)
+			.HAlign(HAlign_Center)
+			[
+				SNew(SImage)
+				.Image(FAppStyle::GetBrush("SourceControl.Branch"))
+			]
+			+ SHorizontalBox::Slot()
+			.AutoWidth()
+			.VAlign(VAlign_Center)
+			.Padding(FMargin(5, 0, 0, 0))
+			[
+				SNew(STextBlock)
+				.TextStyle(&FAppStyle::Get().GetWidgetStyle<FTextBlockStyle>("NormalText"))
+				.Text_Lambda([this]() { return GetStatusBarText(); })
+			]
+		]
+	];
+}
+
+FText SPlasticSourceControlStatusBar::GetStatusBarText() const
+{;
+	return FText::FromString(FPlasticSourceControlModule::Get().GetProvider().GetBranchName());
+}
+
+FReply SPlasticSourceControlStatusBar::OnClicked()
+{
+	return FReply::Handled();
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlStatusBar.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlStatusBar.cpp
@@ -4,6 +4,13 @@
 
 #include "PlasticSourceControlModule.h"
 
+#include "Runtime/Launch/Resources/Version.h"
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
+#include "Styling/AppStyle.h"
+#else
+#include "EditorStyleSet.h"
+#endif
+
 #define LOCTEXT_NAMESPACE "PlasticSourceControl"
 
 void SPlasticSourceControlStatusBar::Construct(const FArguments& InArgs)
@@ -22,8 +29,12 @@ void SPlasticSourceControlStatusBar::Construct(const FArguments& InArgs)
 			.VAlign(VAlign_Center)
 			.HAlign(HAlign_Center)
 			[
-				SNew(SImage)
+				SNew(SImage)	
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
 				.Image(FAppStyle::GetBrush("SourceControl.Branch"))
+#else
+				.Image(FEditorStyle::GetBrush("SourceControl.Branch"))
+#endif
 			]
 			+ SHorizontalBox::Slot()
 			.AutoWidth()

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlStatusBar.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlStatusBar.h
@@ -1,0 +1,24 @@
+// Copyright (c) 2023 Unity Technologies
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+#include "Widgets/SCompoundWidget.h"
+
+/**
+ * Status bar displaying the name of the current branch
+ */
+class SPlasticSourceControlStatusBar : public SCompoundWidget
+{
+public:
+	SLATE_BEGIN_ARGS(SPlasticSourceControlStatusBar)	{}
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+
+private:
+	FText GetStatusBarText() const;
+
+	FReply OnClicked();
+};


### PR DESCRIPTION
Add a SPlasticSourceControlStatusBar displaying the name of the current branch in the status bar

Unreal Engine 5 only, as there was not equivalent status bar in UE4