### PR TITLE
Fix "Update Workspace status on Editor startup"

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -177,7 +177,7 @@ bool FPlasticConnectWorker::Execute(FPlasticSourceControlCommand& InCommand)
 					PlasticSourceControlShell::SetShellIsWarmedUp();
 					TArray<FString> ContentDir;
 					ContentDir.Add(FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()));
-					PlasticSourceControlUtils::RunUpdateStatus(ContentDir, PlasticSourceControlUtils::EStatusSearchType::ControlledOnly, false, InCommand.ErrorMessages, States, InCommand.ChangesetNumber, InCommand.BranchName);
+					PlasticSourceControlUtils::RunUpdateStatus(ContentDir, PlasticSourceControlUtils::EStatusSearchType::All, false, InCommand.ErrorMessages, States, InCommand.ChangesetNumber, InCommand.BranchName);
 				}
 			}
 			else

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -23,6 +23,7 @@
 
 #include "ISourceControlModule.h"
 #include "SourceControlOperations.h"
+#include <PlasticSourceControlShell.h>
 
 #define LOCTEXT_NAMESPACE "PlasticSourceControl"
 
@@ -171,8 +172,9 @@ bool FPlasticConnectWorker::Execute(FPlasticSourceControlCommand& InCommand)
 				// Now update the status of assets in the Content directory
 				// but only on real (re-)connection (but not each time Login() is called by Rename or Fixup Redirector command to check connection)
 				// and only if enabled in the settings
-				if (!GetProvider().IsAvailable() && GetProvider().AccessSettings().GetUpdateStatusAtStartup())
+				if (!PlasticSourceControlShell::GetShellIsWarmedUp() && GetProvider().AccessSettings().GetUpdateStatusAtStartup())
 				{
+					PlasticSourceControlShell::SetShellIsWarmedUp();
 					TArray<FString> ContentDir;
 					ContentDir.Add(FPaths::ConvertRelativePathToFull(FPaths::ProjectContentDir()));
 					PlasticSourceControlUtils::RunUpdateStatus(ContentDir, PlasticSourceControlUtils::EStatusSearchType::ControlledOnly, false, InCommand.ErrorMessages, States, InCommand.ChangesetNumber, InCommand.BranchName);

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -7,6 +7,7 @@
 #include "PlasticSourceControlModule.h"
 #include "PlasticSourceControlProvider.h"
 #include "PlasticSourceControlSettings.h"
+#include "PlasticSourceControlShell.h"
 #include "PlasticSourceControlState.h"
 #include "PlasticSourceControlUtils.h"
 #include "PlasticSourceControlVersions.h"
@@ -23,7 +24,6 @@
 
 #include "ISourceControlModule.h"
 #include "SourceControlOperations.h"
-#include <PlasticSourceControlShell.h>
 
 #define LOCTEXT_NAMESPACE "PlasticSourceControl"
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlShell.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlShell.cpp
@@ -393,7 +393,7 @@ void SetShellIsWarmedUp()
 bool GetShellIsWarmedUp()
 {
 	FScopeLock Lock(&ShellCriticalSection);
-	
+
 	return _GetShellIsWarmedUp();
 }
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlShell.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlShell.cpp
@@ -70,6 +70,9 @@ static FCriticalSection	ShellCriticalSection;
 static size_t			ShellCommandCounter = -1;
 static double			ShellCumulatedTime = 0.;
 
+// Whether we already ran a status command to warm up the current shell process
+static bool             bShellIsWarmedUp = false;
+
 // Internal function to cleanup (called under the critical section)
 static void _CleanupBackgroundCommandLineShell()
 {
@@ -77,6 +80,16 @@ static void _CleanupBackgroundCommandLineShell()
 	FPlatformProcess::ClosePipe(ShellInputPipeRead, ShellInputPipeWrite);
 	ShellOutputPipeRead = ShellOutputPipeWrite = nullptr;
 	ShellInputPipeRead = ShellInputPipeWrite = nullptr;
+}
+
+static bool _GetShellIsWarmedUp()
+{
+	return bShellIsWarmedUp;
+}
+
+static void _SetShellIsWarmedUp()
+{
+	bShellIsWarmedUp = true;
 }
 
 // Internal function to launch the Unity Version Control background 'cm' process in interactive shell mode (called under the critical section)
@@ -89,6 +102,8 @@ static bool _StartBackgroundPlasticShell(const FString& InPathToPlasticBinary, c
 	const bool bLaunchDetached = false;				// the new process will NOT have its own window
 	const bool bLaunchHidden = true;				// the new process will be minimized in the task bar
 	const bool bLaunchReallyHidden = bLaunchHidden; // the new process will not have a window or be in the task bar
+
+	bShellIsWarmedUp = false;
 
 	const double StartTimestamp = FPlatformTime::Seconds();
 
@@ -366,6 +381,20 @@ void Terminate()
 	FScopeLock Lock(&ShellCriticalSection);
 
 	_ExitBackgroundCommandLineShell();
+}
+
+void SetShellIsWarmedUp()
+{
+	FScopeLock Lock(&ShellCriticalSection);
+
+	_SetShellIsWarmedUp();
+}
+
+bool GetShellIsWarmedUp()
+{
+	FScopeLock Lock(&ShellCriticalSection);
+	
+	return _GetShellIsWarmedUp();
 }
 
 // Run command and return the raw result

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlShell.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlShell.h
@@ -26,6 +26,16 @@ bool Launch(const FString& InPathToPlasticBinary, const FString& InWorkspaceRoot
 /** Terminate the background 'cm shell' process and associated pipes */
 void Terminate();
 
+/** Mark the current shell process as already warmed up - i.e. we already ran a preliminary 'status' command. */
+void SetShellIsWarmedUp();
+
+/**
+ * Retrieve whether the current shell process was already warmed up - i.e. we already ran a preliminary 'status' command.
+ *
+ * @returns true if the shell process was already warmed up
+ */
+bool GetShellIsWarmedUp();
+
 
 /**
  * Run a Plastic command - the result is the output of cm, as a multi-line string.


### PR DESCRIPTION
# Fix "Update Workspace status on Editor startup"

## Description

@SRombautsU analysed the issue.

The option to "Run an asynchronous Update Status at Editor startup (can be slow)." doesn't work anymore since we made a fix to run the initial connection much earlier at `Init()` of the plugin. Since then, in daily work, the connection has already been established before the first call to the "Connect" operation by the Unreal Editor.

As a consequence, `FPlasticConnectWorker::Execute()` is never called with `IsAvailable()` being false.

This regression has been introduced by Commit [60dffefd](https://github.com/PlasticSCM/UEPlasticPlugin/pull/29/commits/60dffefdf48d1460cb8d6acdb5a9b5ef6cf49942) by Sébastien Rombauts, 05/12/2022 04:05 PM

```
Fix FPlasticSourceControlProvider::Init() to respect bForceConnection

Execute a 'checkconnection' command to set bServerAvailable based on the connectivity of the server
```

In pull request #29 - Fix connection at init for commandlets.

## Steps to reproduce

1. From the global source control menu, open "Change Revision Control Settings"
2. Enable Update workspace Status at Editor startup
3. Close the Unreal Editor properly to ensure the flag is saved
4. Restart Unreal Editor and check the notifications and the logs

## Expected behaviour

* A global `status` operation is called on the whole `Content/` directory a Editor startup from the "connect" operation

## Actual behaviour

* There is no such an "status" command visible in the logs