### PR TITLE
Visualize the list of branches

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlBranch.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlBranch.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2023 Unity Technologies
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+class FPlasticSourceControlBranch
+{
+public:
+	FPlasticSourceControlBranch() = default;
+	FPlasticSourceControlBranch(const FString& InName, const FString& InRepository, const FString& InCreatedBy, const FDateTime& InDate, const FString& InComment)
+		: Name(InName)
+		, Repository(InRepository)
+		, CreatedBy(InCreatedBy)
+		, Date(InDate)
+		, Comment(InComment)
+	{}
+	FString Name;
+	FString Repository;
+	FString CreatedBy;
+	FDateTime Date;
+	FString Comment;
+
+	void PopulateSearchString(TArray<FString>& OutStrings) const
+	{
+		OutStrings.Emplace(Name);
+		OutStrings.Emplace(CreatedBy);
+		OutStrings.Emplace(Comment);
+	}
+};
+
+typedef TSharedRef<class FPlasticSourceControlBranch, ESPMode::ThreadSafe> FPlasticSourceControlBranchRef;
+typedef TSharedPtr<class FPlasticSourceControlBranch, ESPMode::ThreadSafe> FPlasticSourceControlBranchPtr;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlBranchesWindow.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlBranchesWindow.cpp
@@ -19,7 +19,7 @@ void FPlasticSourceControlBranchesWindow::Register()
 	FGlobalTabmanager::Get()->RegisterNomadTabSpawner(PlasticSourceControlWindowTabName, FOnSpawnTab::CreateRaw(this, &FPlasticSourceControlBranchesWindow::OnSpawnTab))
 		.SetDisplayName(LOCTEXT("PlasticSourceControlWindowTabTitle", "View Branches"))
 		.SetMenuType(ETabSpawnerMenuType::Hidden)
-	.SetIcon(FSlateIcon(FPlasticSourceControlStyle::Get().GetStyleSetName(), "PlasticSourceControl.PluginIcon.Small"));
+		.SetIcon(FSlateIcon(FPlasticSourceControlStyle::Get().GetStyleSetName(), "PlasticSourceControl.PluginIcon.Small"));
 }
 
 void FPlasticSourceControlBranchesWindow::Unregister()

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlBranchesWindow.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlBranchesWindow.cpp
@@ -1,0 +1,51 @@
+// Copyright (c) 2023 Unity Technologies
+
+#include "PlasticSourceControlBranchesWindow.h"
+
+#include "Widgets/Docking/SDockTab.h"
+
+#include "PlasticSourceControlStyle.h"
+#include "SPlasticSourceControlBranchesWidget.h"
+
+#define LOCTEXT_NAMESPACE "PlasticSourceControlWindow"
+
+static const FName PlasticSourceControlWindowTabName("PlasticSourceControlWindow");
+
+void FPlasticSourceControlBranchesWindow::Register()
+{
+	FPlasticSourceControlStyle::Initialize();
+	FPlasticSourceControlStyle::ReloadTextures();
+
+	FGlobalTabmanager::Get()->RegisterNomadTabSpawner(PlasticSourceControlWindowTabName, FOnSpawnTab::CreateRaw(this, &FPlasticSourceControlBranchesWindow::OnSpawnTab))
+		.SetDisplayName(LOCTEXT("PlasticSourceControlWindowTabTitle", "View Branches"))
+		.SetMenuType(ETabSpawnerMenuType::Hidden)
+	.SetIcon(FSlateIcon(FPlasticSourceControlStyle::Get().GetStyleSetName(), "PlasticSourceControl.PluginIcon.Small"));
+}
+
+void FPlasticSourceControlBranchesWindow::Unregister()
+{
+	FGlobalTabmanager::Get()->UnregisterNomadTabSpawner(PlasticSourceControlWindowTabName);
+
+	FPlasticSourceControlStyle::Shutdown();
+}
+
+TSharedRef<SDockTab> FPlasticSourceControlBranchesWindow::OnSpawnTab(const FSpawnTabArgs& SpawnTabArgs)
+{
+	return SNew(SDockTab)
+		.TabRole(ETabRole::NomadTab)
+		[
+			CreateBranchesWidget().ToSharedRef()
+		];
+}
+
+void FPlasticSourceControlBranchesWindow::OpenTab()
+{
+	FGlobalTabmanager::Get()->TryInvokeTab(PlasticSourceControlWindowTabName);
+}
+
+TSharedPtr<SWidget> FPlasticSourceControlBranchesWindow::CreateBranchesWidget()
+{
+	return SNew(SPlasticSourceControlBranchesWidget);
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlBranchesWindow.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlBranchesWindow.h
@@ -1,0 +1,20 @@
+// Copyright (c) 2023 Unity Technologies
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+// Nomad tab window to hold the widget with the list of branches, see SPlasticSourceControlBranchesWidget
+class FPlasticSourceControlBranchesWindow
+{
+public:
+	void Register();
+	void Unregister();
+
+	void OpenTab();
+
+private:
+	TSharedRef<class SDockTab> OnSpawnTab(const class FSpawnTabArgs& SpawnTabArgs);
+
+	TSharedPtr<SWidget> CreateBranchesWidget();
+};

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.h
@@ -28,6 +28,7 @@ public:
 	void VisitDocsURLClicked() const;
 	void VisitSupportURLClicked() const;
 	void VisitLockRulesURLClicked(const FString InOrganizationName) const;
+	void OpenBranchesWindow() const;
 
 private:
 	bool IsSourceControlConnected() const;
@@ -37,10 +38,12 @@ private:
 
 #if ENGINE_MAJOR_VERSION == 4
 	void AddMenuExtension(FMenuBuilder& Menu);
+	void AddViewBranches(FMenuBuilder& Menu);
 
 	TSharedRef<class FExtender> OnExtendLevelEditorViewMenu(const TSharedRef<class FUICommandList> CommandList);
 #elif ENGINE_MAJOR_VERSION == 5
 	void AddMenuExtension(FToolMenuSection& Menu);
+	void AddViewBranches(FToolMenuSection& Menu);
 #endif
 
 	/** Extends the UE5 toolbar with a status bar widget to display the current branch and open the branch tab */

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlModule.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlModule.cpp
@@ -18,12 +18,17 @@ void FPlasticSourceControlModule::StartupModule()
 
 	// Bind our source control provider to the editor
 	IModularFeatures::Get().RegisterModularFeature("SourceControl", &PlasticSourceControlProvider);
+
+	/// Register our tab Window here as it needs to be ready for the editor to reload at startup
+	PlasticSourceControlBranchesWindow.Register();
 }
 
 void FPlasticSourceControlModule::ShutdownModule()
 {
 	// shut down the provider, as this module is going away
 	PlasticSourceControlProvider.Close();
+
+	PlasticSourceControlBranchesWindow.Unregister();
 
 	// unbind provider from editor
 	IModularFeatures::Get().UnregisterModularFeature("SourceControl", &PlasticSourceControlProvider);

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlModule.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlModule.h
@@ -8,6 +8,8 @@
 #include "PlasticSourceControlProvider.h"
 #include "PlasticSourceControlWorkspaceCreation.h"
 
+#include "PlasticSourceControlBranchesWindow.h"
+
 /**
  * PlasticSourceControl is the official Unity Version Control Plugin for Unreal Engine
  *
@@ -36,6 +38,11 @@ public:
 		return PlasticSourceControlWorkspaceCreation;
 	}
 
+	FPlasticSourceControlBranchesWindow& GetBranchesWindow()
+	{
+		return PlasticSourceControlBranchesWindow;
+	}
+
 	/**
 	 * Singleton-like access to this module's interface.  This is just for convenience!
 	 * Beware of calling this during the shutdown phase, though.  Your module might have been unloaded already.
@@ -59,6 +66,8 @@ public:
 private:
 	/** The Plastic source control provider */
 	FPlasticSourceControlProvider PlasticSourceControlProvider;
+
+	FPlasticSourceControlBranchesWindow PlasticSourceControlBranchesWindow;
 
 	/** Logic to create a new workspace */
 	FPlasticSourceControlWorkspaceCreation PlasticSourceControlWorkspaceCreation;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
@@ -19,6 +19,8 @@
 #endif
 
 class FPlasticSourceControlProvider;
+typedef TSharedRef<class FPlasticSourceControlBranch, ESPMode::ThreadSafe> FPlasticSourceControlBranchRef;
+
 
 /**
  * Internal operation used to revert checked-out unchanged files
@@ -111,6 +113,25 @@ public:
 
 	// Release the Lock(s), and optionally remove (delete) them completely
 	bool bRemove = false;
+};
+
+
+/**
+ * Internal operation to list branches, aka "cm find branch"
+*/
+class FPlasticGetBranches final : public ISourceControlOperation
+{
+public:
+	// ISourceControlOperation interface
+	virtual FName GetName() const override;
+
+	virtual FText GetInProgressString() const override;
+
+	// Limit the list of branches to ones created from this date
+	FDateTime FromDate;
+
+	// List of branches found
+	TArray<FPlasticSourceControlBranchRef> Branches;
 };
 
 
@@ -335,6 +356,23 @@ public:
 public:
 	/** Temporary states for results */
 	TArray<FPlasticSourceControlState> States;
+};
+
+/** list branches. */
+class FPlasticGetBranchesWorker final : public IPlasticSourceControlWorker
+{
+public:
+	explicit FPlasticGetBranchesWorker(FPlasticSourceControlProvider& InSourceControlProvider)
+		: IPlasticSourceControlWorker(InSourceControlProvider)
+	{}
+	virtual ~FPlasticGetBranchesWorker() = default;
+	// IPlasticSourceControlWorker interface
+	virtual FName GetName() const override;
+	virtual bool Execute(class FPlasticSourceControlCommand& InCommand) override;
+	virtual bool UpdateStates() override;
+
+	// Current branch the workspace is on
+	FString CurrentBranchName;
 };
 
 /** Plastic update the workspace to latest changes */

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProjectSettings.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProjectSettings.h
@@ -28,4 +28,20 @@ public:
 	/** If a non-null value is set, limit the maximum number of revisions requested to Unity Version Control to display in the "History" window. */
 	UPROPERTY(config, EditAnywhere, Category = "Unity Version Control", meta = (ClampMin = 0))
 	int32 LimitNumberOfRevisionsInHistory = 50;
+
+	/** Show the repository when the branch is created (hidden by default) */
+	UPROPERTY(config, EditAnywhere, Category = "Unity Version Control")
+	bool bShowBranchRepositoryColumn = false;
+
+	/* Show the name of the creator of the branch */
+	UPROPERTY(config, EditAnywhere, Category = "Unity Version Control")
+	bool bShowBranchCreatedByColumn = true;
+
+	/* Show the date of creation of the branch */
+	UPROPERTY(config, EditAnywhere, Category = "Unity Version Control")
+	bool bShowBranchDateColumn = true;
+
+	/* Show the comment of the branch */
+	UPROPERTY(config, EditAnywhere, Category = "Unity Version Control")
+	bool bShowBranchCommentColumn = true;
 };

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.h
@@ -126,6 +126,10 @@ public:
 	{
 		return BranchName;
 	}
+	inline void SetBranchName(FString&& InBranchName)
+	{
+		BranchName = InBranchName;
+	}
 
 	/** Get the current Changeset Number */
 	inline int32 GetChangesetNumber() const

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlStyle.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlStyle.cpp
@@ -5,7 +5,9 @@
 #include "Framework/Application/SlateApplication.h"
 #include "Interfaces/IPluginManager.h"
 #include "Slate/SlateGameResources.h"
+#if ENGINE_MAJOR_VERSION >= 5
 #include "Styling/SlateStyleMacros.h"
+#endif
 #include "Styling/SlateStyleRegistry.h"
 
 #include "PlasticSourceControlModule.h"

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlStyle.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlStyle.cpp
@@ -1,0 +1,68 @@
+// Copyright (c) 2023 Unity Technologies
+
+#include "PlasticSourceControlStyle.h"
+
+#include "Framework/Application/SlateApplication.h"
+#include "Interfaces/IPluginManager.h"
+#include "Slate/SlateGameResources.h"
+#include "Styling/SlateStyleMacros.h"
+#include "Styling/SlateStyleRegistry.h"
+
+#include "PlasticSourceControlModule.h"
+
+TSharedPtr<FSlateStyleSet> FPlasticSourceControlStyle::StyleInstance = nullptr;
+
+void FPlasticSourceControlStyle::Initialize()
+{
+	if (!StyleInstance.IsValid())
+	{
+		StyleInstance = Create();
+		FSlateStyleRegistry::RegisterSlateStyle(*StyleInstance);
+	}
+}
+
+void FPlasticSourceControlStyle::Shutdown()
+{
+	FSlateStyleRegistry::UnRegisterSlateStyle(*StyleInstance);
+	ensure(StyleInstance.IsUnique());
+	StyleInstance.Reset();
+}
+
+FName FPlasticSourceControlStyle::GetStyleSetName()
+{
+	static FName StyleSetName(TEXT("PlasticSourceControlStyle"));
+	return StyleSetName;
+}
+
+const FVector2D Icon16x16(16.0f, 16.0f);
+
+TSharedRef<FSlateStyleSet> FPlasticSourceControlStyle::Create()
+{
+	TSharedRef<FSlateStyleSet> Style = MakeShareable(new FSlateStyleSet("PlasticSourceControlStyle"));
+	Style->SetContentRoot(FPlasticSourceControlModule::GetPlugin()->GetBaseDir() / TEXT("Resources"));
+
+	Style->Set("PlasticSourceControl.PluginIcon.Small", new FSlateImageBrush(FPlasticSourceControlStyle::InContent("Icon128", ".png"), Icon16x16));
+
+	return Style;
+}
+
+FString FPlasticSourceControlStyle::InContent(const FString& RelativePath, const ANSICHAR* Extension)
+{
+	auto myself = FPlasticSourceControlModule::GetPlugin();
+	check(myself.IsValid());
+	static FString ContentDir = myself->GetBaseDir() / TEXT("Resources");
+	return (ContentDir / RelativePath) + Extension;
+}
+
+void FPlasticSourceControlStyle::ReloadTextures()
+{
+	if (FSlateApplication::IsInitialized())
+	{
+		FSlateApplication::Get().GetRenderer()->ReloadTextureResources();
+	}
+}
+
+const ISlateStyle& FPlasticSourceControlStyle::Get()
+{
+	return *StyleInstance;
+}

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlStyle.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlStyle.h
@@ -1,0 +1,31 @@
+// Copyright (c) 2023 Unity Technologies
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Styling/SlateStyle.h"
+
+class FPlasticSourceControlStyle
+{
+public:
+	static void Initialize();
+
+	static void Shutdown();
+
+	/** reloads textures used by slate renderer */
+	static void ReloadTextures();
+
+	/** @return The Slate style set */
+	static const ISlateStyle& Get();
+
+	static FName GetStyleSetName();
+
+private:
+	static TSharedRef<class FSlateStyleSet> Create();
+
+private:
+	static FString InContent(const FString& RelativePath, const ANSICHAR* Extension);
+
+private:
+	static TSharedPtr<class FSlateStyleSet> StyleInstance;
+};

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -2370,7 +2370,7 @@ bool RunGetBranches(const FDateTime& InFromDate, TArray<FPlasticSourceControlBra
 	TArray<FString> Parameters;
 	if (InFromDate != FDateTime())
 	{
-		Parameters.Add(FString::Printf(TEXT("\"branches where date >= '%s'\""), *InFromDate.ToFormattedString(TEXT("%Y/%m/%d"))));
+		Parameters.Add(FString::Printf(TEXT("\"branches where date >= '%d/%d/%d'\""), InFromDate.GetYear(), InFromDate.GetMonth(), InFromDate.GetDay()));
 	}
 	else
 	{

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+
 #include "PlasticSourceControlRevision.h"
 
 #include "Runtime/Launch/Resources/Version.h"
@@ -11,6 +12,7 @@ class FPlasticSourceControlChangelistState;
 class FPlasticSourceControlCommand;
 class FPlasticSourceControlState;
 struct FSoftwareVersion;
+typedef TSharedRef<class FPlasticSourceControlBranch, ESPMode::ThreadSafe> FPlasticSourceControlBranchRef;
 
 enum class EWorkspaceState;
 
@@ -214,6 +216,14 @@ bool RunGetShelve(const int32 InShelveId, FString& OutComment, FDateTime& OutDat
 void AddShelvedFileToChangelist(FPlasticSourceControlChangelistState& InOutChangelistsState, FString&& InFilename, EWorkspaceState InShelveStatus, FString&& InMovedFrom);
 
 #endif
+
+/**
+ * Run find "branches where date >= 'YYYY/MM/DD'" and parse the results.
+ * @param	InFromDate				The list of branches
+ * @param	OutBranches				The list of branches
+ * @param	OutErrorMessages		Any errors (from StdErr) as an array per-line
+ */
+bool RunGetBranches(const FDateTime& InFromDate, TArray<FPlasticSourceControlBranchRef>& OutBranches, TArray<FString>& OutErrorMessages);
 
 /**
  * Helper function for various commands to update cached states.

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchRow.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchRow.cpp
@@ -55,6 +55,8 @@ TSharedRef<SWidget> SPlasticSourceControlBranchRow::GenerateWidgetForColumn(cons
 		return SNew(STextBlock)
 			.Text(FText::FromString(BranchToVisualize->Name))
 			.ToolTipText(FText::FromString(BranchToVisualize->Name))
+			.Margin(FMargin(6.f, 1.f))
+			.OverflowPolicy(ETextOverflowPolicy::Ellipsis)
 			.Font(FontInfo)
 			.HighlightText(HighlightText);
 	}
@@ -63,6 +65,7 @@ TSharedRef<SWidget> SPlasticSourceControlBranchRow::GenerateWidgetForColumn(cons
 		return SNew(STextBlock)
 			.Text(FText::FromString(BranchToVisualize->Repository))
 			.ToolTipText(FText::FromString(BranchToVisualize->Repository))
+			.Margin(FMargin(6.f, 1.f))
 			.Font(FontInfo)
 			.HighlightText(HighlightText);
 	}
@@ -71,6 +74,7 @@ TSharedRef<SWidget> SPlasticSourceControlBranchRow::GenerateWidgetForColumn(cons
 		return SNew(STextBlock)
 			.Text(FText::FromString(BranchToVisualize->CreatedBy))
 			.ToolTipText(FText::FromString(BranchToVisualize->CreatedBy))
+			.Margin(FMargin(6.f, 1.f))
 			.Font(FontInfo)
 			.HighlightText(HighlightText);
 	}
@@ -79,13 +83,19 @@ TSharedRef<SWidget> SPlasticSourceControlBranchRow::GenerateWidgetForColumn(cons
 		return SNew(STextBlock)
 			.Text(FText::AsDateTime(BranchToVisualize->Date))
 			.ToolTipText(FText::AsDateTime(BranchToVisualize->Date))
+			.Margin(FMargin(6.f, 1.f))
 			.Font(FontInfo);
 	}
 	else if (InColumnId == PlasticSourceControlBranchesListViewColumn::Comment::Id())
 	{
+		FString CommentOnOneLine = BranchToVisualize->Comment;
+		CommentOnOneLine.ReplaceCharInline(TEXT('\n'), TEXT(' '), ESearchCase::CaseSensitive);
+
 		return SNew(STextBlock)
-			.Text(FText::FromString(BranchToVisualize->Comment))
+			.Text(FText::FromString(MoveTemp(CommentOnOneLine)))
 			.ToolTipText(FText::FromString(BranchToVisualize->Comment))
+			.Margin(FMargin(6.f, 1.f))
+			.OverflowPolicy(ETextOverflowPolicy::Ellipsis)
 			.Font(FontInfo)
 			.HighlightText(HighlightText);
 	}

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchRow.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchRow.cpp
@@ -1,0 +1,98 @@
+// Copyright (c) 2023 Unity Technologies
+
+#include "SPlasticSourceControlBranchRow.h"
+
+#include "PlasticSourceControlBranch.h"
+
+#include "Widgets/Text/STextBlock.h"
+
+#include "Runtime/Launch/Resources/Version.h"
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
+#include "Styling/AppStyle.h"
+#else
+#include "EditorStyleSet.h"
+#endif
+
+#define LOCTEXT_NAMESPACE "PlasticSourceControlWindow"
+
+FName PlasticSourceControlBranchesListViewColumn::Name::Id() { return TEXT("Name"); }
+FText PlasticSourceControlBranchesListViewColumn::Name::GetDisplayText() { return LOCTEXT("Name_Column", "Name"); }
+FText PlasticSourceControlBranchesListViewColumn::Name::GetToolTipText() { return LOCTEXT("Name_Column_Tooltip", "Displays the asset/file name"); }
+
+FName PlasticSourceControlBranchesListViewColumn::Repository::Id() { return TEXT("Repository"); }
+FText PlasticSourceControlBranchesListViewColumn::Repository::GetDisplayText() { return LOCTEXT("Repository_Column", "Repository"); }
+FText PlasticSourceControlBranchesListViewColumn::Repository::GetToolTipText() { return LOCTEXT("Repository_Column_Tooltip", "Displays the repository where the branch has been created"); }
+
+FName PlasticSourceControlBranchesListViewColumn::CreatedBy::Id() { return TEXT("CreatedBy"); }
+FText PlasticSourceControlBranchesListViewColumn::CreatedBy::GetDisplayText() { return LOCTEXT("CreatedBy_Column", "Created by"); }
+FText PlasticSourceControlBranchesListViewColumn::CreatedBy::GetToolTipText() { return LOCTEXT("CreatedBy_Column_Tooltip", "Displays the name of the creator of the branch"); }
+
+FName PlasticSourceControlBranchesListViewColumn::Date::Id() { return TEXT("Date"); }
+FText PlasticSourceControlBranchesListViewColumn::Date::GetDisplayText() { return LOCTEXT("Date_Column", "Creation date"); }
+FText PlasticSourceControlBranchesListViewColumn::Date::GetToolTipText() { return LOCTEXT("Date_Column_Tooltip", "Displays the branch creation date"); }
+
+FName PlasticSourceControlBranchesListViewColumn::Comment::Id() { return TEXT("Comment"); }
+FText PlasticSourceControlBranchesListViewColumn::Comment::GetDisplayText() { return LOCTEXT("Comment_Column", "Comment"); }
+FText PlasticSourceControlBranchesListViewColumn::Comment::GetToolTipText() { return LOCTEXT("Comment_Column_Tooltip", "Displays the branch comment"); }
+
+void SPlasticSourceControlBranchRow::Construct(const FArguments& InArgs, const TSharedRef<STableViewBase>& InOwner)
+{
+	BranchToVisualize = static_cast<FPlasticSourceControlBranch*>(InArgs._BranchToVisualize.Get());
+	bIsCurrentBranch = InArgs._bIsCurrentBranch.Get();
+	HighlightText = InArgs._HighlightText;
+
+	FSuperRowType::FArguments Args = FSuperRowType::FArguments()
+		.ShowSelection(true);
+	FSuperRowType::Construct(Args, InOwner);
+}
+
+TSharedRef<SWidget> SPlasticSourceControlBranchRow::GenerateWidgetForColumn(const FName& InColumnId)
+{
+	const FSlateFontInfo FontInfo = bIsCurrentBranch ? FAppStyle::GetFontStyle("BoldFont") : FAppStyle::GetFontStyle("NormalFont");
+
+	if (InColumnId == PlasticSourceControlBranchesListViewColumn::Name::Id())
+	{
+		return SNew(STextBlock)
+			.Text(FText::FromString(BranchToVisualize->Name))
+			.ToolTipText(FText::FromString(BranchToVisualize->Name))
+			.Font(FontInfo)
+			.HighlightText(HighlightText);
+	}
+	else if (InColumnId == PlasticSourceControlBranchesListViewColumn::Repository::Id())
+	{
+		return SNew(STextBlock)
+			.Text(FText::FromString(BranchToVisualize->Repository))
+			.ToolTipText(FText::FromString(BranchToVisualize->Repository))
+			.Font(FontInfo)
+			.HighlightText(HighlightText);
+	}
+	else if (InColumnId == PlasticSourceControlBranchesListViewColumn::CreatedBy::Id())
+	{
+		return SNew(STextBlock)
+			.Text(FText::FromString(BranchToVisualize->CreatedBy))
+			.ToolTipText(FText::FromString(BranchToVisualize->CreatedBy))
+			.Font(FontInfo)
+			.HighlightText(HighlightText);
+	}
+	else if (InColumnId == PlasticSourceControlBranchesListViewColumn::Date::Id())
+	{
+		return SNew(STextBlock)
+			.Text(FText::AsDateTime(BranchToVisualize->Date))
+			.ToolTipText(FText::AsDateTime(BranchToVisualize->Date))
+			.Font(FontInfo);
+	}
+	else if (InColumnId == PlasticSourceControlBranchesListViewColumn::Comment::Id())
+	{
+		return SNew(STextBlock)
+			.Text(FText::FromString(BranchToVisualize->Comment))
+			.ToolTipText(FText::FromString(BranchToVisualize->Comment))
+			.Font(FontInfo)
+			.HighlightText(HighlightText);
+	}
+	else
+	{
+		return SNullWidget::NullWidget;
+	}
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchRow.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchRow.cpp
@@ -48,7 +48,11 @@ void SPlasticSourceControlBranchRow::Construct(const FArguments& InArgs, const T
 
 TSharedRef<SWidget> SPlasticSourceControlBranchRow::GenerateWidgetForColumn(const FName& InColumnId)
 {
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
 	const FSlateFontInfo FontInfo = bIsCurrentBranch ? FAppStyle::GetFontStyle("BoldFont") : FAppStyle::GetFontStyle("NormalFont");
+#else
+	const FSlateFontInfo FontInfo = bIsCurrentBranch ? FEditorStyle::GetFontStyle("BoldFont") : FEditorStyle::GetFontStyle("NormalFont");
+#endif
 
 	if (InColumnId == PlasticSourceControlBranchesListViewColumn::Name::Id())
 	{
@@ -56,7 +60,9 @@ TSharedRef<SWidget> SPlasticSourceControlBranchRow::GenerateWidgetForColumn(cons
 			.Text(FText::FromString(BranchToVisualize->Name))
 			.ToolTipText(FText::FromString(BranchToVisualize->Name))
 			.Margin(FMargin(6.f, 1.f))
+#if ENGINE_MAJOR_VERSION >= 5
 			.OverflowPolicy(ETextOverflowPolicy::Ellipsis)
+#endif
 			.Font(FontInfo)
 			.HighlightText(HighlightText);
 	}
@@ -95,7 +101,9 @@ TSharedRef<SWidget> SPlasticSourceControlBranchRow::GenerateWidgetForColumn(cons
 			.Text(FText::FromString(MoveTemp(CommentOnOneLine)))
 			.ToolTipText(FText::FromString(BranchToVisualize->Comment))
 			.Margin(FMargin(6.f, 1.f))
+#if ENGINE_MAJOR_VERSION >= 5
 			.OverflowPolicy(ETextOverflowPolicy::Ellipsis)
+#endif
 			.Font(FontInfo)
 			.HighlightText(HighlightText);
 	}

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchRow.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchRow.h
@@ -1,0 +1,93 @@
+// Copyright (c) 2023 Unity Technologies
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/Views/STableRow.h"
+#include "Widgets/Views/STableViewBase.h"
+
+typedef TSharedRef<class FPlasticSourceControlBranch, ESPMode::ThreadSafe> FPlasticSourceControlBranchRef;
+typedef TSharedPtr<class FPlasticSourceControlBranch, ESPMode::ThreadSafe> FPlasticSourceControlBranchPtr;
+
+class FPlasticSourceControlBranch;
+
+/** Lists the unique columns used in the list view displaying branches. */
+namespace PlasticSourceControlBranchesListViewColumn
+{
+	/** The branch Name column. */
+	namespace Name // NOLINT(runtime/indentation_namespace)
+	{
+		FName Id();
+		FText GetDisplayText();
+		FText GetToolTipText();
+	};
+
+	/** The branch Repository column. */
+	namespace Repository // NOLINT(runtime/indentation_namespace)
+	{
+		FName Id();
+		FText GetDisplayText();
+		FText GetToolTipText();
+	};
+
+	/** The branch CreatedBy column. */
+	namespace CreatedBy // NOLINT(runtime/indentation_namespace)
+	{
+		FName Id();
+		FText GetDisplayText();
+		FText GetToolTipText();
+	};
+
+	/** The branch Date column. */
+	namespace Date // NOLINT(runtime/indentation_namespace)
+	{
+		FName Id();
+		FText GetDisplayText();
+		FText GetToolTipText();
+	};
+
+	/** The branch Comment column. */
+	namespace Comment // NOLINT(runtime/indentation_namespace)
+	{
+		FName Id();
+		FText GetDisplayText();
+		FText GetToolTipText();
+	}
+} // namespace PlasticSourceControlBranchesListViewColumn
+
+class SPlasticSourceControlBranchRow : public SMultiColumnTableRow<FPlasticSourceControlBranchRef>
+{
+public:
+	SLATE_BEGIN_ARGS(SPlasticSourceControlBranchRow)
+		: _BranchToVisualize(nullptr)
+		, _bIsCurrentBranch(false)
+		, _HighlightText()
+	{
+	}
+		SLATE_ARGUMENT(FPlasticSourceControlBranchPtr, BranchToVisualize)
+		SLATE_ATTRIBUTE(bool, bIsCurrentBranch)
+		SLATE_ATTRIBUTE(FText, HighlightText)
+	SLATE_END_ARGS()
+
+public:
+	/**
+	* Construct a row child widgets of the ListView.
+	*
+	* @param InArgs Parameters including the branch to visualize in this row.
+	* @param InOwner The owning ListView.
+	*/
+	void Construct(const FArguments& InArgs, const TSharedRef<STableViewBase>& InOwner);
+
+	// SMultiColumnTableRow overrides
+	virtual TSharedRef<SWidget> GenerateWidgetForColumn(const FName& ColumnId) override;
+
+private:
+	/** The branch that we are visualizing in this row. */
+	FPlasticSourceControlBranch* BranchToVisualize;
+
+	/** True if this is the current branch, to be highlighted on the list of branches. */
+	bool bIsCurrentBranch;
+
+	/** The search text to highlight if any */
+	TAttribute<FText> HighlightText;
+};

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
@@ -332,7 +332,7 @@ void SPlasticSourceControlBranchesWidget::SortBranchView()
 {
 	TRACE_CPUPROFILER_EVENT_SCOPE(SPlasticSourceControlBranchesWidget::SortBranchView);
 
-	if (PrimarySortedColumn.IsNone() || BranchRows.IsEmpty())
+	if (PrimarySortedColumn.IsNone() || BranchRows.Num() == 0)
 	{
 		return; // No column selected for sorting or nothing to sort.
 	}

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
@@ -488,9 +488,9 @@ void SPlasticSourceControlBranchesWidget::RequestBranchesRefresh()
 
 	StartRefreshStatus();
 
+	TSharedRef<FPlasticGetBranches, ESPMode::ThreadSafe> GetBranchesOperation = ISourceControlOperation::Create<FPlasticGetBranches>();
 	// TODO POC FAKE:
-	TSharedRef<FUpdateStatus, ESPMode::ThreadSafe> GetBranchesOperation = ISourceControlOperation::Create<FUpdateStatus>();
-	GetBranchesOperation->SetGetOpenedOnly(true);
+	GetBranchesOperation->FromDate = FDateTime(2023, 10, 18);
 
 	ISourceControlProvider& SourceControlProvider = ISourceControlModule::Get().GetProvider();
 	SourceControlProvider.Execute(GetBranchesOperation, EConcurrency::Asynchronous, FSourceControlOperationComplete::CreateSP(this, &SPlasticSourceControlBranchesWidget::OnBranchesUpdated));
@@ -524,9 +524,11 @@ void SPlasticSourceControlBranchesWidget::OnSourceControlProviderChanged(ISource
 
 void SPlasticSourceControlBranchesWidget::OnBranchesUpdated(const TSharedRef<ISourceControlOperation>& InOperation, ECommandResult::Type InType)
 {
-	TRACE_CPUPROFILER_EVENT_SCOPE(SSourceControlChangelistsWidget::OnSourceControlStateChanged);
+	TRACE_CPUPROFILER_EVENT_SCOPE(SSourceControlChangelistsWidget::OnBranchesUpdated);
 
-	// NOTE: This is invoked when the 'FPlasticSourceControl' completes.
+	TSharedRef<FPlasticGetBranches, ESPMode::ThreadSafe> Operation = StaticCastSharedRef<FPlasticGetBranches>(InOperation);
+	SourceControlBranches = MoveTemp(Operation->Branches);
+
 	OnEndSourceControlOperation(InOperation, InType);
 	EndRefreshStatus();
 	OnRefreshUI();

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
@@ -1,0 +1,189 @@
+// Copyright (c) 2023 Unity Technologies
+
+#include "SPlasticSourceControlBranchesWidget.h"
+
+#include "Widgets/Images/SImage.h"
+#include "Widgets/Input/SEditableTextBox.h"
+#include "Widgets/Text/STextBlock.h"
+
+#define LOCTEXT_NAMESPACE "PlasticSourceControlWindow"
+
+// TODO: transition to a proper SMultiColumnTableRow
+// see Engine\Source\Editor\SourceControlWindows\Private\SSourceControlChangelistRows.h
+// class SFileTableRow : public SMultiColumnTableRow<FChangelistTreeItemPtr>
+
+void SPlasticSourceControlBranchesWidget::Construct(const FArguments& InArgs)
+{
+	ChildSlot
+	[
+		SNew(SVerticalBox)
+		+SVerticalBox::Slot()
+		.AutoHeight()
+		[
+			SNew(SHorizontalBox)
+			+SHorizontalBox::Slot()
+			.VAlign(VAlign_Center)
+			.AutoWidth()
+			[
+				SNew(SImage)
+				.Image(FAppStyle::GetBrush("Icons.Search"))
+			]
+			+SHorizontalBox::Slot()
+			.MaxWidth(300)
+			[
+				SNew(SEditableTextBox)
+				.Justification(ETextJustify::Left)
+				.HintText(LOCTEXT("Search", "Search"))
+				.OnTextChanged(this, &SPlasticSourceControlBranchesWidget::OnSearchTextChanged)
+			]
+		]
+		+SVerticalBox::Slot()
+		.AutoHeight()
+		.Padding(0, 5, 0, 0)
+		.Expose(ContentSlot)
+		[
+			CreateContentPanel()
+		]
+	];
+
+	RegisterActiveTimer(60.f, FWidgetActiveTimerDelegate::CreateSP(this, &SPlasticSourceControlBranchesWidget::UpdateContentSlot));
+}
+
+TSharedRef<SWidget> SPlasticSourceControlBranchesWidget::CreateContentPanel()
+{
+	// TODO: transition to a proper ListView widget
+	TSharedRef<SGridPanel> Panel =
+		SNew(SGridPanel);
+
+	const float RowMargin = 0.0f;
+	const float ColumnMargin = 10.0f;
+	const FSlateColor TitleColor = FStyleColors::AccentWhite;
+	const FSlateFontInfo TitleFont = FCoreStyle::GetDefaultFontStyle("Bold", 10);
+	const FMargin DefaultMarginFirstColumn(ColumnMargin, RowMargin);
+
+	int32 Row = 0;
+
+	const FMargin TitleMargin(0.0f, 10.0f, ColumnMargin, 10.0f);
+	const FMargin TitleMarginFirstColumn(ColumnMargin, 10.0f);
+	const FMargin DefaultMargin(0.0f, RowMargin, ColumnMargin, RowMargin);
+
+	Panel->AddSlot(0, Row)
+	[
+		SNew(STextBlock)
+	];
+
+	Panel->AddSlot(1, Row)
+	[
+		SNew(STextBlock)
+		.Margin(TitleMarginFirstColumn)
+		.Font(FCoreStyle::GetDefaultFontStyle("Bold", 10))
+		.ColorAndOpacity(TitleColor)
+		.Text(LOCTEXT("BranchName", "Name"))
+	];
+
+	Panel->AddSlot(2, Row)
+	[
+		SNew(STextBlock)
+		.Margin(TitleMargin)
+		.ColorAndOpacity(TitleColor)
+		.Font(TitleFont)
+		.Text(LOCTEXT("CreateBy", "Created By"))
+	];
+
+	Panel->AddSlot(3, Row)
+	[
+		SNew(STextBlock)
+		.Margin(TitleMargin)
+		.ColorAndOpacity(TitleColor)
+		.Font(TitleFont)
+		.Text(LOCTEXT("CreationDate", "Creation date"))
+	];
+
+	Panel->AddSlot(4, Row)
+	[
+		SNew(STextBlock)
+		.Margin(TitleMargin)
+		.ColorAndOpacity(TitleColor)
+		.Font(TitleFont)
+		.Text(LOCTEXT("Comment", "Comment"))
+	];
+
+
+	// POC
+	for (int32 i = 0; i < 10; i++)
+	{
+		// TODO: POC fake branch info
+		const FString BranchName = (i == 0) ? FString(TEXT("/main")) : FString::Printf(TEXT("/main/scm%d"), 100271 + (i * i));
+		const FString BranchCreatedBy = TEXT("sebastien.rombauts@unity3d.com");
+		const FString BranchCreationDate = TEXT("23/10/2023 14:24:14");
+		const FString BranchComment = FString::Printf(TEXT("Proof of Concept comment for branch %s"), *BranchName);
+
+		// Filter branches on name, author and comment
+		if ((BranchName.Find(FilterText) == INDEX_NONE) && (BranchCreatedBy.Find(FilterText) == INDEX_NONE) && (BranchComment.Find(FilterText) == INDEX_NONE))
+		{
+			continue;
+		}
+
+		Row++;
+
+		Panel->AddSlot(0, Row)
+		[
+			SNew(STextBlock)
+		];
+
+		Panel->AddSlot(1, Row)
+		.HAlign(HAlign_Left)
+		[
+			SNew(STextBlock)
+			.Margin(DefaultMargin)
+			.Text(FText::FromString(BranchName))
+		];
+
+		Panel->AddSlot(2, Row)
+		.HAlign(HAlign_Left)
+		[
+			SNew(STextBlock)
+			.Margin(DefaultMargin)
+			.Text(FText::FromString(BranchCreatedBy))
+		];
+
+		Panel->AddSlot(3, Row)
+		.HAlign(HAlign_Left)
+		[
+			SNew(STextBlock)
+			.Margin(DefaultMargin)
+			.Text(FText::FromString(BranchCreationDate))
+		];
+
+		Panel->AddSlot(4, Row)
+		.HAlign(HAlign_Left)
+		[
+			SNew(STextBlock)
+			.Margin(DefaultMargin)
+			.Text(FText::FromString(BranchComment))
+		];
+	}
+
+	return Panel;
+}
+
+EActiveTimerReturnType SPlasticSourceControlBranchesWidget::UpdateContentSlot(double InCurrentTime, float InDeltaTime)
+{
+	(*ContentSlot)
+		[
+			CreateContentPanel()
+		];
+
+	SlatePrepass(GetPrepassLayoutScaleMultiplier());
+
+	return EActiveTimerReturnType::Continue;
+}
+
+void SPlasticSourceControlBranchesWidget::OnSearchTextChanged(const FText& SearchText)
+{
+	FilterText = SearchText.ToString();
+
+	UpdateContentSlot(0.0, 0.0f);
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
@@ -9,7 +9,11 @@
 #include "SPlasticSourceControlBranchRow.h"
 
 #include "ISourceControlModule.h"
+
+#include "Runtime/Launch/Resources/Version.h"
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 3
 #include "Misc/ComparisonUtility.h"
+#endif
 #include "Widgets/Input/SSearchBox.h"
 #include "Widgets/Text/STextBlock.h"
 #include "Widgets/Views/SHeaderRow.h"
@@ -339,7 +343,11 @@ void SPlasticSourceControlBranchesWidget::SortBranchView()
 
 	auto CompareNames = [](const FPlasticSourceControlBranch* Lhs, const FPlasticSourceControlBranch* Rhs)
 	{
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 3
 		return UE::ComparisonUtility::CompareNaturalOrder(*Lhs->Name, *Rhs->Name);
+#else
+		return FCString::Stricmp(*Lhs->Name, *Rhs->Name);
+#endif
 	};
 
 	auto CompareRepository = [](const FPlasticSourceControlBranch* Lhs, const FPlasticSourceControlBranch* Rhs)

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
@@ -14,6 +14,11 @@
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 3
 #include "Misc/ComparisonUtility.h"
 #endif
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
+#include "Styling/AppStyle.h"
+#else
+#include "EditorStyleSet.h"
+#endif
 #include "Widgets/Input/SSearchBox.h"
 #include "Widgets/Text/STextBlock.h"
 #include "Widgets/Views/SHeaderRow.h"
@@ -36,7 +41,11 @@ void SPlasticSourceControlBranchesWidget::Construct(const FArguments& InArgs)
 		.AutoHeight()
 		[
 			SNew(SBorder)
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
 			.BorderImage(FAppStyle::GetBrush("ToolPanel.GroupBorder"))
+#else
+			.BorderImage(FEditorStyle::GetBrush("DetailsView.CategoryBottom"))
+#endif
 			.Padding(4)
 			[
 				SNew(SHorizontalBox)
@@ -71,7 +80,7 @@ void SPlasticSourceControlBranchesWidget::Construct(const FArguments& InArgs)
 		.AutoHeight()
 		[
 			SNew(SBox)
-			.Padding(0, 3)
+			.Padding(FMargin(0.f, 3.f))
 			[
 				SNew(SHorizontalBox)
 				+SHorizontalBox::Slot()
@@ -104,7 +113,11 @@ void SPlasticSourceControlBranchesWidget::Construct(const FArguments& InArgs)
 
 TSharedRef<SWidget> SPlasticSourceControlBranchesWidget::CreateToolBar()
 {
+#if ENGINE_MAJOR_VERSION >= 5
 	FSlimHorizontalToolBarBuilder ToolBarBuilder(nullptr, FMultiBoxCustomization::None);
+#else
+	FToolBarBuilder ToolBarBuilder(nullptr, FMultiBoxCustomization::None);
+#endif
 
 	ToolBarBuilder.AddToolBarButton(
 		FUIAction(
@@ -112,7 +125,11 @@ TSharedRef<SWidget> SPlasticSourceControlBranchesWidget::CreateToolBar()
 		NAME_None,
 		LOCTEXT("SourceControl_RefreshButton", "Refresh"),
 		LOCTEXT("SourceControl_RefreshButton_Tooltip", "Refreshes branches from revision control provider."),
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
 		FSlateIcon(FAppStyle::GetAppStyleSetName(), "SourceControl.Actions.Refresh"));
+#else
+		FSlateIcon(FEditorStyle::GetStyleSetName(), "SourceControl.Actions.Refresh"));
+#endif
 
 	return ToolBarBuilder.MakeWidget();
 }

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
@@ -6,11 +6,13 @@
 #include "PlasticSourceControlOperations.h"
 #include "PlasticSourceControlProjectSettings.h"
 #include "PlasticSourceControlBranch.h"
+#include "SPlasticSourceControlBranchRow.h"
 
 #include "ISourceControlModule.h"
 #include "Misc/ComparisonUtility.h"
 #include "Widgets/Input/SSearchBox.h"
 #include "Widgets/Text/STextBlock.h"
+#include "Widgets/Views/SHeaderRow.h"
 
 #define LOCTEXT_NAMESPACE "PlasticSourceControlWindow"
 
@@ -191,7 +193,7 @@ TSharedRef<SWidget> SPlasticSourceControlBranchesWidget::CreateContentPanel()
 TSharedRef<ITableRow> SPlasticSourceControlBranchesWidget::OnGenerateRow(FPlasticSourceControlBranchRef InBranch, const TSharedRef<STableViewBase>& OwnerTable)
 {
 	const bool bIsCurrentBranch = InBranch->Name == CurrentBranchName;
-	return SNew(SBranchTableRow, OwnerTable)
+	return SNew(SPlasticSourceControlBranchRow, OwnerTable)
 		.BranchToVisualize(InBranch)
 		.bIsCurrentBranch(bIsCurrentBranch)
 		.HighlightText_Lambda([this]() { return FileSearchBox->GetText(); });
@@ -543,86 +545,6 @@ void SPlasticSourceControlBranchesWidget::OnBranchesUpdated(const TSharedRef<ISo
 	OnEndSourceControlOperation(InOperation, InType);
 	EndRefreshStatus();
 	OnRefreshUI();
-}
-
-FName PlasticSourceControlBranchesListViewColumn::Name::Id() { return TEXT("Name"); }
-FText PlasticSourceControlBranchesListViewColumn::Name::GetDisplayText() { return LOCTEXT("Name_Column", "Name"); }
-FText PlasticSourceControlBranchesListViewColumn::Name::GetToolTipText() { return LOCTEXT("Name_Column_Tooltip", "Displays the asset/file name"); }
-
-FName PlasticSourceControlBranchesListViewColumn::Repository::Id() { return TEXT("Repository"); }
-FText PlasticSourceControlBranchesListViewColumn::Repository::GetDisplayText() { return LOCTEXT("Repository_Column", "Repository"); }
-FText PlasticSourceControlBranchesListViewColumn::Repository::GetToolTipText() { return LOCTEXT("Repository_Column_Tooltip", "Displays the repository where the branch has been created"); }
-
-FName PlasticSourceControlBranchesListViewColumn::CreatedBy::Id() { return TEXT("CreatedBy"); }
-FText PlasticSourceControlBranchesListViewColumn::CreatedBy::GetDisplayText() { return LOCTEXT("CreatedBy_Column", "Created by"); }
-FText PlasticSourceControlBranchesListViewColumn::CreatedBy::GetToolTipText() { return LOCTEXT("CreatedBy_Column_Tooltip", "Displays the name of the creator of the branch"); }
-
-FName PlasticSourceControlBranchesListViewColumn::Date::Id() { return TEXT("Date"); }
-FText PlasticSourceControlBranchesListViewColumn::Date::GetDisplayText() { return LOCTEXT("Date_Column", "Creation date"); }
-FText PlasticSourceControlBranchesListViewColumn::Date::GetToolTipText() { return LOCTEXT("Date_Column_Tooltip", "Displays the branch creation date"); }
-
-FName PlasticSourceControlBranchesListViewColumn::Comment::Id() { return TEXT("Comment"); }
-FText PlasticSourceControlBranchesListViewColumn::Comment::GetDisplayText() { return LOCTEXT("Comment_Column", "Comment"); }
-FText PlasticSourceControlBranchesListViewColumn::Comment::GetToolTipText() { return LOCTEXT("Comment_Column_Tooltip", "Displays the branch comment"); }
-
-void SBranchTableRow::Construct(const FArguments& InArgs, const TSharedRef<STableViewBase>& InOwner)
-{
-	BranchToVisualize = static_cast<FPlasticSourceControlBranch*>(InArgs._BranchToVisualize.Get());
-	bIsCurrentBranch = InArgs._bIsCurrentBranch.Get();
-	HighlightText = InArgs._HighlightText;
-
-	FSuperRowType::FArguments Args = FSuperRowType::FArguments()
-		.ShowSelection(true);
-	FSuperRowType::Construct(Args, InOwner);
-}
-
-TSharedRef<SWidget> SBranchTableRow::GenerateWidgetForColumn(const FName& InColumnId)
-{
-	const FSlateFontInfo FontInfo = bIsCurrentBranch ? FAppStyle::GetFontStyle("BoldFont") : FAppStyle::GetFontStyle("NormalFont");
-
-	if (InColumnId == PlasticSourceControlBranchesListViewColumn::Name::Id())
-	{
-		return SNew(STextBlock)
-			.Text(FText::FromString(BranchToVisualize->Name))
-			.ToolTipText(FText::FromString(BranchToVisualize->Name))
-			.Font(FontInfo)
-			.HighlightText(HighlightText);
-	}
-	else if (InColumnId == PlasticSourceControlBranchesListViewColumn::Repository::Id())
-	{
-		return SNew(STextBlock)
-			.Text(FText::FromString(BranchToVisualize->Repository))
-			.ToolTipText(FText::FromString(BranchToVisualize->Repository))
-			.Font(FontInfo)
-			.HighlightText(HighlightText);
-	}
-	else if (InColumnId == PlasticSourceControlBranchesListViewColumn::CreatedBy::Id())
-	{
-		return SNew(STextBlock)
-			.Text(FText::FromString(BranchToVisualize->CreatedBy))
-			.ToolTipText(FText::FromString(BranchToVisualize->CreatedBy))
-			.Font(FontInfo)
-			.HighlightText(HighlightText);
-	}
-	else if (InColumnId == PlasticSourceControlBranchesListViewColumn::Date::Id())
-	{
-		return SNew(STextBlock)
-			.Text(FText::AsDateTime(BranchToVisualize->Date))
-			.ToolTipText(FText::AsDateTime(BranchToVisualize->Date))
-			.Font(FontInfo);
-	}
-	else if (InColumnId == PlasticSourceControlBranchesListViewColumn::Comment::Id())
-	{
-		return SNew(STextBlock)
-			.Text(FText::FromString(BranchToVisualize->Comment))
-			.ToolTipText(FText::FromString(BranchToVisualize->Comment))
-			.Font(FontInfo)
-			.HighlightText(HighlightText);
-	}
-	else
-	{
-		return SNullWidget::NullWidget;
-	}
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
@@ -5,6 +5,7 @@
 #include "PlasticSourceControlModule.h"
 #include "PlasticSourceControlOperations.h"
 #include "PlasticSourceControlProjectSettings.h"
+#include "PlasticSourceControlBranch.h"
 
 #include "ISourceControlModule.h"
 #include "Misc/ComparisonUtility.h"

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
@@ -403,7 +403,7 @@ void SPlasticSourceControlBranchesWidget::SortBranchView()
 		// NOTE: StableSort() would give a better experience when the sorted columns(s) has the same values and new values gets added, but it is slower
 		//       with large changelists (7600 items was about 1.8x slower in average measured with Unreal Insight). Because this code runs in the main
 		//       thread and can be invoked a lot, the trade off went if favor of speed.
-		BranchRows.Sort([this, &PrimaryCompare, &SecondaryCompare](const TSharedPtr<FPlasticSourceControlBranch>& Lhs, const TSharedPtr<FPlasticSourceControlBranch>& Rhs)
+		BranchRows.Sort([this, &PrimaryCompare, &SecondaryCompare](const FPlasticSourceControlBranchPtr& Lhs, const FPlasticSourceControlBranchPtr& Rhs)
 		{
 			int32 Result = PrimaryCompare(static_cast<FPlasticSourceControlBranch*>(Lhs.Get()), static_cast<FPlasticSourceControlBranch*>(Rhs.Get()));
 			if (Result < 0)
@@ -426,7 +426,7 @@ void SPlasticSourceControlBranchesWidget::SortBranchView()
 	}
 	else
 	{
-		BranchRows.Sort([this, &PrimaryCompare, &SecondaryCompare](const TSharedPtr<FPlasticSourceControlBranch>& Lhs, const TSharedPtr<FPlasticSourceControlBranch>& Rhs)
+		BranchRows.Sort([this, &PrimaryCompare, &SecondaryCompare](const FPlasticSourceControlBranchPtr& Lhs, const FPlasticSourceControlBranchPtr& Rhs)
 		{
 			int32 Result = PrimaryCompare(static_cast<FPlasticSourceControlBranch*>(Lhs.Get()), static_cast<FPlasticSourceControlBranch*>(Rhs.Get()));
 			if (Result > 0)
@@ -512,12 +512,12 @@ void SPlasticSourceControlBranchesWidget::RequestBranchesRefresh()
 	OnStartSourceControlOperation(GetBranchesOperation, LOCTEXT("SourceControl_UpdatingChangelist", "Updating branches..."));
 }
 
-void SPlasticSourceControlBranchesWidget::OnStartSourceControlOperation(const TSharedRef<ISourceControlOperation> InOperation, const FText& InMessage)
+void SPlasticSourceControlBranchesWidget::OnStartSourceControlOperation(const TSharedRef<ISourceControlOperation, ESPMode::ThreadSafe> InOperation, const FText& InMessage)
 {
 	RefreshStatus = InMessage;
 }
 
-void SPlasticSourceControlBranchesWidget::OnEndSourceControlOperation(const TSharedRef<ISourceControlOperation>& InOperation, ECommandResult::Type InType)
+void SPlasticSourceControlBranchesWidget::OnEndSourceControlOperation(const TSharedRef<ISourceControlOperation, ESPMode::ThreadSafe>& InOperation, ECommandResult::Type InType)
 {
 	RefreshStatus = FText::GetEmpty();
 }
@@ -537,7 +537,7 @@ void SPlasticSourceControlBranchesWidget::OnSourceControlProviderChanged(ISource
 	}
 }
 
-void SPlasticSourceControlBranchesWidget::OnBranchesUpdated(const TSharedRef<ISourceControlOperation>& InOperation, ECommandResult::Type InType)
+void SPlasticSourceControlBranchesWidget::OnBranchesUpdated(const TSharedRef<ISourceControlOperation, ESPMode::ThreadSafe>& InOperation, ECommandResult::Type InType)
 {
 	TRACE_CPUPROFILER_EVENT_SCOPE(SSourceControlChangelistsWidget::OnBranchesUpdated);
 

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
@@ -72,14 +72,22 @@ void SPlasticSourceControlBranchesWidget::Construct(const FArguments& InArgs)
 				SNew(SHorizontalBox)
 				+SHorizontalBox::Slot()
 				.HAlign(HAlign_Left)
-				.VAlign(VAlign_Center)
+				.AutoWidth()
 				[
 					SNew(STextBlock)
 					.Text_Lambda([this]() { return RefreshStatus; })
+					.Margin(FMargin(5.f, 0.f))
+				]
+				+SHorizontalBox::Slot()
+				.HAlign(HAlign_Left)
+				.AutoWidth()
+				[
+					SNew(STextBlock)
+					.Text_Lambda([this]() { return FText::AsNumber(BranchRows.Num()); })
+					.ToolTipText(LOCTEXT("PlasticBranchesNumber_Tooltip", "Number of branches displayed after filtering by date and by search keywords."))
 				]
 				+SHorizontalBox::Slot()
 				.HAlign(HAlign_Right)
-				.VAlign(VAlign_Center)
 				[
 					SNew(STextBlock)
 					.Text_Lambda([this]() { return FText::FromString(CurrentBranchName); })

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
@@ -5,16 +5,12 @@
 #include "CoreMinimal.h"
 #include "Misc/TextFilter.h"
 #include "Widgets/SCompoundWidget.h"
-#include "Widgets/Views/SHeaderRow.h"
 #include "Widgets/Views/SListView.h"
-#include "Widgets/Views/STableRow.h"
-#include "Widgets/Views/STableViewBase.h"
 
 #include "ISourceControlOperation.h"
 #include "ISourceControlProvider.h"
 
 typedef TSharedRef<class FPlasticSourceControlBranch, ESPMode::ThreadSafe> FPlasticSourceControlBranchRef;
-typedef TSharedPtr<class FPlasticSourceControlBranch, ESPMode::ThreadSafe> FPlasticSourceControlBranchPtr;
 
 class SSearchBox;
 
@@ -87,90 +83,4 @@ private:
 
 	TArray<FPlasticSourceControlBranchRef> SourceControlBranches; // Full list from source (filtered by date)
 	TArray<FPlasticSourceControlBranchRef> BranchRows; // Filtered list to display based on the search text filter
-};
-
-
-// TODO: move the following to its own file
-// Inspired by class SFileTableRow : public SMultiColumnTableRow<FChangelistTreeItemPtr> in SSourceControlChangelistRows.h
-
-
-/** Lists the unique columns used in the list view displaying branches. */
-namespace PlasticSourceControlBranchesListViewColumn
-{
-	/** The branch Name column. */
-	namespace Name // NOLINT(runtime/indentation_namespace)
-	{
-		FName Id();
-		FText GetDisplayText();
-		FText GetToolTipText();
-	};
-
-	/** The branch Repository column. */
-	namespace Repository // NOLINT(runtime/indentation_namespace)
-	{
-		FName Id();
-		FText GetDisplayText();
-		FText GetToolTipText();
-	};
-
-	/** The branch CreatedBy column. */
-	namespace CreatedBy // NOLINT(runtime/indentation_namespace)
-	{
-		FName Id();
-		FText GetDisplayText();
-		FText GetToolTipText();
-	};
-
-	/** The branch Date column. */
-	namespace Date // NOLINT(runtime/indentation_namespace)
-	{
-		FName Id();
-		FText GetDisplayText();
-		FText GetToolTipText();
-	};
-
-	/** The branch Comment column. */
-	namespace Comment // NOLINT(runtime/indentation_namespace)
-	{
-		FName Id();
-		FText GetDisplayText();
-		FText GetToolTipText();
-	}
-} // namespace PlasticSourceControlBranchesListViewColumn
-
-class SBranchTableRow : public SMultiColumnTableRow<FPlasticSourceControlBranchRef>
-{
-public:
-	SLATE_BEGIN_ARGS(SBranchTableRow)
-		: _BranchToVisualize(nullptr)
-		, _bIsCurrentBranch(false)
-		, _HighlightText()
-	{
-	}
-		SLATE_ARGUMENT(FPlasticSourceControlBranchPtr, BranchToVisualize)
-		SLATE_ATTRIBUTE(bool, bIsCurrentBranch)
-		SLATE_ATTRIBUTE(FText, HighlightText)
-	SLATE_END_ARGS()
-
-public:
-	/**
-	* Construct a row child widgets of the ListView.
-	*
-	* @param InArgs Parameters including the branch to visualize in this row.
-	* @param InOwner The owning ListView.
-	*/
-	void Construct(const FArguments& InArgs, const TSharedRef<STableViewBase>& InOwner);
-
-	// SMultiColumnTableRow overrides
-	virtual TSharedRef<SWidget> GenerateWidgetForColumn(const FName& ColumnId) override;
-
-private:
-	/** The branch that we are visualizing in this row. */
-	FPlasticSourceControlBranch* BranchToVisualize;
-
-	/** True if this is the current branch, to be highlighted on the list of branches. */
-	bool bIsCurrentBranch;
-
-	/** The search text to highlight if any */
-	TAttribute<FText> HighlightText;
 };

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
@@ -56,6 +56,8 @@ private:
 	EColumnSortMode::Type GetColumnSortMode(const FName InColumnId) const;
 	void OnColumnSortModeChanged(const EColumnSortPriority::Type InSortPriority, const FName& InColumnId, const EColumnSortMode::Type InSortMode);
 
+	void SortBranchView();
+
 	SListView<FPlasticSourceControlBranchRef>* GetListView() const
 	{
 		return BranchesListView.Get();

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
@@ -4,6 +4,37 @@
 
 #include "CoreMinimal.h"
 #include "Widgets/SCompoundWidget.h"
+#include "Widgets/Views/SHeaderRow.h"
+#include "Widgets/Views/SListView.h"
+#include "Widgets/Views/STableRow.h"
+#include "Widgets/Views/STableViewBase.h"
+
+
+// TODO: move the following to their own file(s)
+// Inspired by class SFileTableRow : public SMultiColumnTableRow<FChangelistTreeItemPtr> in SSourceControlChangelistRows.h
+class FPlasticSourceControlBranch
+{
+public:
+	FPlasticSourceControlBranch(const FString& InName, const FString& InRepository, const FString& InCreatedBy, const FDateTime& InDate, const FString& InComment)
+		: Name(InName)
+		, Repository(InRepository)
+		, CreatedBy(InCreatedBy)
+		, Date(InDate)
+		, Comment(InComment)
+	{}
+	FString Name;
+	FString Repository;
+	FString CreatedBy;
+	FDateTime Date;
+	FString Comment;
+};
+
+
+class SSearchBox;
+
+typedef TSharedRef<class FPlasticSourceControlBranch, ESPMode::ThreadSafe> FPlasticSourceControlBranchRef;
+typedef TSharedPtr<class FPlasticSourceControlBranch, ESPMode::ThreadSafe> FPlasticSourceControlBranchPtr;
+
 
 // Widget displaying the list of branches in the tab window, see FPlasticSourceControlBranchesWindow
 class SPlasticSourceControlBranchesWidget : public SCompoundWidget
@@ -15,9 +46,114 @@ class SPlasticSourceControlBranchesWidget : public SCompoundWidget
 
 private:
 	TSharedRef<SWidget> CreateContentPanel();
-	EActiveTimerReturnType UpdateContentSlot(double InCurrentTime, float InDeltaTime);
-	SVerticalBox::FSlot* ContentSlot = nullptr;
 
-	FString FilterText;
-	void OnSearchTextChanged(const FText& SearchText);
+	TSharedRef<ITableRow> OnGenerateRow(FPlasticSourceControlBranchRef InBranch, const TSharedRef<STableViewBase>& OwnerTable);
+	void OnHiddenColumnsListChanged();
+
+	void OnSearchTextChanged(const FText& InFilterText);
+
+	EColumnSortPriority::Type GetColumnSortPriority(const FName InColumnId) const;
+	EColumnSortMode::Type GetColumnSortMode(const FName InColumnId) const;
+	void OnColumnSortModeChanged(const EColumnSortPriority::Type InSortPriority, const FName& InColumnId, const EColumnSortMode::Type InSortMode);
+
+	SListView<FPlasticSourceControlBranchRef>* GetListView() const
+	{
+		return BranchesListView.Get();
+	}
+
+private:
+	TSharedPtr<SSearchBox> FileSearchBox;
+
+	FName PrimarySortedColumn;
+	FName SecondarySortedColumn;
+	EColumnSortMode::Type PrimarySortMode = EColumnSortMode::Ascending;
+	EColumnSortMode::Type SecondarySortMode = EColumnSortMode::None;
+
+	TArray<FName> HiddenColumnsList;
+
+	TSharedPtr<SListView<FPlasticSourceControlBranchRef>> BranchesListView;
+
+	TArray<FPlasticSourceControlBranchRef> SourceControlBranches; // Full list from source (filtered by date)
+	TArray<FPlasticSourceControlBranchRef> BranchRows; // Filtered list to display based on the search text filter
+};
+
+
+// TODO: move the following to its own file
+// Inspired by class SFileTableRow : public SMultiColumnTableRow<FChangelistTreeItemPtr> in SSourceControlChangelistRows.h
+
+
+/** Lists the unique columns used in the list view displaying branches. */
+namespace PlasticSourceControlBranchesListViewColumn
+{
+	/** The branch Name column. */
+	namespace Name // NOLINT(runtime/indentation_namespace)
+	{
+		FName Id();
+		FText GetDisplayText();
+		FText GetToolTipText();
+	};
+
+	/** The branch Repository column. */
+	namespace Repository // NOLINT(runtime/indentation_namespace)
+	{
+		FName Id();
+		FText GetDisplayText();
+		FText GetToolTipText();
+	};
+
+	/** The branch CreatedBy column. */
+	namespace CreatedBy // NOLINT(runtime/indentation_namespace)
+	{
+		FName Id();
+		FText GetDisplayText();
+		FText GetToolTipText();
+	};
+
+	/** The branch Date column. */
+	namespace Date // NOLINT(runtime/indentation_namespace)
+	{
+		FName Id();
+		FText GetDisplayText();
+		FText GetToolTipText();
+	};
+
+	/** The branch Comment column. */
+	namespace Comment // NOLINT(runtime/indentation_namespace)
+	{
+		FName Id();
+		FText GetDisplayText();
+		FText GetToolTipText();
+	}
+} // namespace PlasticSourceControlBranchesListViewColumn
+
+class SBranchTableRow : public SMultiColumnTableRow<FPlasticSourceControlBranchRef>
+{
+public:
+	SLATE_BEGIN_ARGS(SBranchTableRow)
+		: _BranchToVisualize(nullptr)
+		, _HighlightText()
+	{
+	}
+		SLATE_ARGUMENT(FPlasticSourceControlBranchPtr, BranchToVisualize)
+		SLATE_ATTRIBUTE(FText, HighlightText)
+	SLATE_END_ARGS()
+
+public:
+	/**
+	* Construct a row child widgets of the ListView.
+	*
+	* @param InArgs Parameters including the branch to visualize in this row.
+	* @param InOwner The owning ListView.
+	*/
+	void Construct(const FArguments& InArgs, const TSharedRef<STableViewBase>& InOwner);
+
+	// SMultiColumnTableRow overrides
+	virtual TSharedRef<SWidget> GenerateWidgetForColumn(const FName& ColumnId) override;
+
+private:
+	/** The branch that we are visualizing in this row. */
+	FPlasticSourceControlBranch* BranchToVisualize;
+
+	/** The search text to highlight if any */
+	TAttribute<FText> HighlightText;
 };

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
@@ -45,9 +45,9 @@ private:
 	void EndRefreshStatus();
 
 	void RequestBranchesRefresh();
-	void OnBranchesUpdated(const TSharedRef<ISourceControlOperation>& InOperation, ECommandResult::Type InType);
-	void OnStartSourceControlOperation(const TSharedRef<ISourceControlOperation> InOperation, const FText& InMessage);
-	void OnEndSourceControlOperation(const TSharedRef<ISourceControlOperation>& InOperation, ECommandResult::Type InType);
+	void OnBranchesUpdated(const TSharedRef<ISourceControlOperation, ESPMode::ThreadSafe>& InOperation, ECommandResult::Type InType);
+	void OnStartSourceControlOperation(const TSharedRef<ISourceControlOperation, ESPMode::ThreadSafe> InOperation, const FText& InMessage);
+	void OnEndSourceControlOperation(const TSharedRef<ISourceControlOperation, ESPMode::ThreadSafe>& InOperation, ECommandResult::Type InType);
 
 	/** Source control callbacks */
 	void OnSourceControlProviderChanged(ISourceControlProvider& OldProvider, ISourceControlProvider& NewProvider);

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
@@ -1,0 +1,23 @@
+// Copyright (c) 2023 Unity Technologies
+
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Widgets/SCompoundWidget.h"
+
+// Widget displaying the list of branches in the tab window, see FPlasticSourceControlBranchesWindow
+class SPlasticSourceControlBranchesWidget : public SCompoundWidget
+{
+	SLATE_BEGIN_ARGS(SPlasticSourceControlBranchesWidget) {}
+	SLATE_END_ARGS()
+
+	void Construct(const FArguments& InArgs);
+
+private:
+	TSharedRef<SWidget> CreateContentPanel();
+	EActiveTimerReturnType UpdateContentSlot(double InCurrentTime, float InDeltaTime);
+	SVerticalBox::FSlot* ContentSlot = nullptr;
+
+	FString FilterText;
+	void OnSearchTextChanged(const FText& SearchText);
+};

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
@@ -3,6 +3,7 @@
 #pragma once
 
 #include "CoreMinimal.h"
+#include "Misc/TextFilter.h"
 #include "Widgets/SCompoundWidget.h"
 #include "Widgets/Views/SHeaderRow.h"
 #include "Widgets/Views/SListView.h"
@@ -27,6 +28,13 @@ public:
 	FString CreatedBy;
 	FDateTime Date;
 	FString Comment;
+
+	void PopulateSearchString(TArray<FString>& OutStrings) const
+	{
+		OutStrings.Emplace(Name);
+		OutStrings.Emplace(CreatedBy);
+		OutStrings.Emplace(Comment);
+	}
 };
 
 
@@ -51,6 +59,8 @@ private:
 	void OnHiddenColumnsListChanged();
 
 	void OnSearchTextChanged(const FText& InFilterText);
+	void PopulateItemSearchStrings(const FPlasticSourceControlBranch& InItem, TArray<FString>& OutStrings);
+	void OnRefreshUI();
 
 	EColumnSortPriority::Type GetColumnSortPriority(const FName InColumnId) const;
 	EColumnSortMode::Type GetColumnSortMode(const FName InColumnId) const;
@@ -74,6 +84,7 @@ private:
 	TArray<FName> HiddenColumnsList;
 
 	TSharedPtr<SListView<FPlasticSourceControlBranchRef>> BranchesListView;
+	TSharedPtr<TTextFilter<const FPlasticSourceControlBranch&>> SearchTextFilter;
 
 	TArray<FPlasticSourceControlBranchRef> SourceControlBranches; // Full list from source (filtered by date)
 	TArray<FPlasticSourceControlBranchRef> BranchRows; // Filtered list to display based on the search text filter

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
@@ -13,38 +13,10 @@
 #include "ISourceControlOperation.h"
 #include "ISourceControlProvider.h"
 
-
-// TODO: move the following to their own file(s)
-// Inspired by class SFileTableRow : public SMultiColumnTableRow<FChangelistTreeItemPtr> in SSourceControlChangelistRows.h
-class FPlasticSourceControlBranch
-{
-public:
-	FPlasticSourceControlBranch(const FString& InName, const FString& InRepository, const FString& InCreatedBy, const FDateTime& InDate, const FString& InComment)
-		: Name(InName)
-		, Repository(InRepository)
-		, CreatedBy(InCreatedBy)
-		, Date(InDate)
-		, Comment(InComment)
-	{}
-	FString Name;
-	FString Repository;
-	FString CreatedBy;
-	FDateTime Date;
-	FString Comment;
-
-	void PopulateSearchString(TArray<FString>& OutStrings) const
-	{
-		OutStrings.Emplace(Name);
-		OutStrings.Emplace(CreatedBy);
-		OutStrings.Emplace(Comment);
-	}
-};
-
-
-class SSearchBox;
-
 typedef TSharedRef<class FPlasticSourceControlBranch, ESPMode::ThreadSafe> FPlasticSourceControlBranchRef;
 typedef TSharedPtr<class FPlasticSourceControlBranch, ESPMode::ThreadSafe> FPlasticSourceControlBranchPtr;
+
+class SSearchBox;
 
 
 // Widget displaying the list of branches in the tab window, see FPlasticSourceControlBranchesWindow

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
@@ -80,6 +80,7 @@ private:
 	bool bIsRefreshing = false;
 	double RefreshStatusStartSecs;
 
+	FString CurrentBranchName;
 
 	TSharedPtr<SListView<FPlasticSourceControlBranchRef>> BranchesListView;
 	TSharedPtr<TTextFilter<const FPlasticSourceControlBranch&>> SearchTextFilter;
@@ -142,10 +143,12 @@ class SBranchTableRow : public SMultiColumnTableRow<FPlasticSourceControlBranchR
 public:
 	SLATE_BEGIN_ARGS(SBranchTableRow)
 		: _BranchToVisualize(nullptr)
+		, _bIsCurrentBranch(false)
 		, _HighlightText()
 	{
 	}
 		SLATE_ARGUMENT(FPlasticSourceControlBranchPtr, BranchToVisualize)
+		SLATE_ATTRIBUTE(bool, bIsCurrentBranch)
 		SLATE_ATTRIBUTE(FText, HighlightText)
 	SLATE_END_ARGS()
 
@@ -164,6 +167,9 @@ public:
 private:
 	/** The branch that we are visualizing in this row. */
 	FPlasticSourceControlBranch* BranchToVisualize;
+
+	/** True if this is the current branch, to be highlighted on the list of branches. */
+	bool bIsCurrentBranch;
 
 	/** The search text to highlight if any */
 	TAttribute<FText> HighlightText;

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
@@ -14,7 +14,6 @@ typedef TSharedRef<class FPlasticSourceControlBranch, ESPMode::ThreadSafe> FPlas
 
 class SSearchBox;
 
-
 // Widget displaying the list of branches in the tab window, see FPlasticSourceControlBranchesWindow
 class SPlasticSourceControlBranchesWidget : public SCompoundWidget
 {
@@ -34,6 +33,10 @@ private:
 
 	void OnSearchTextChanged(const FText& InFilterText);
 	void PopulateItemSearchStrings(const FPlasticSourceControlBranch& InItem, TArray<FString>& OutStrings);
+
+	TSharedRef<SWidget> BuildFromDateDropDownMenu();
+	void OnFromDateChanged(int32 InFromDateInDays);
+
 	void OnRefreshUI();
 
 	EColumnSortPriority::Type GetColumnSortPriority(const FName InColumnId) const;
@@ -80,6 +83,9 @@ private:
 
 	TSharedPtr<SListView<FPlasticSourceControlBranchRef>> BranchesListView;
 	TSharedPtr<TTextFilter<const FPlasticSourceControlBranch&>> SearchTextFilter;
+
+	TMap<int32, FText> FromDateInDaysValues;
+	int32 FromDateInDays = 30;
 
 	TArray<FPlasticSourceControlBranchRef> SourceControlBranches; // Full list from source (filtered by date)
 	TArray<FPlasticSourceControlBranchRef> BranchRows; // Filtered list to display based on the search text filter

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlStatusBar.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlStatusBar.cpp
@@ -20,7 +20,7 @@ void SPlasticSourceControlStatusBar::Construct(const FArguments& InArgs)
 	[
 		SNew(SButton)
 		.ContentPadding(FMargin(6.0f, 0.0f))
-		.ToolTipText(LOCTEXT("PlasticBranches_Tooltip", "Current branch"))
+		.ToolTipText(LOCTEXT("PlasticBranchesWindowTooltip", "Open the Branches window."))
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
 		.ButtonStyle(FAppStyle::Get(), "SimpleButton")
 #else
@@ -65,6 +65,8 @@ FText SPlasticSourceControlStatusBar::GetStatusBarText() const
 
 FReply SPlasticSourceControlStatusBar::OnClicked()
 {
+	FPlasticSourceControlModule::Get().GetBranchesWindow().OpenTab();
+
 	return FReply::Handled();
 }
 


### PR DESCRIPTION
Add a new "View Branches" entry in the "Revision Control" and in the "Tools -> Revision Control" menus, to open a new dockable tab window.

- Display the list of branches, where the user can:
  - filter by creation date
  - search by text
  - sort by any column
  - show/hide columns (and this selection is save in the user's settings)
  - refresh manually to ask the server for the latest update of branches
- The current branch is displayed in bold

It's possible to select a branch, but there is no context menu to act on it (yet).

![image](https://github.com/PlasticSCM/UEPlasticPlugin/assets/101874327/ab4e2a22-d678-437e-adae-06ab3b4184c0)