### PR TITLE
Add a context menu to Switch workspace to branch

### DIFF
--- a/Source/PlasticSourceControl/Private/Notification.cpp
+++ b/Source/PlasticSourceControl/Private/Notification.cpp
@@ -1,0 +1,90 @@
+// Copyright (c) 2023 Unity Technologies
+
+#include "Notification.h"
+
+#include "Widgets/Notifications/SNotificationList.h"
+#include "Framework/Notifications/NotificationManager.h"
+
+#include "Runtime/Launch/Resources/Version.h"
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
+#include "Styling/AppStyle.h"
+#else
+#include "EditorStyleSet.h"
+#endif
+
+#define LOCTEXT_NAMESPACE "PlasticSourceControl"
+
+// Display an ongoing notification during the whole operation
+void FNotification::DisplayInProgress(const FText& InOperationInProgressString)
+{
+	if (!OperationInProgress.IsValid())
+	{
+		FNotificationInfo Info(InOperationInProgressString);
+		Info.bFireAndForget = false;
+		Info.ExpireDuration = 0.0f;
+		Info.FadeOutDuration = 1.0f;
+		OperationInProgress = FSlateNotificationManager::Get().AddNotification(Info);
+		if (OperationInProgress.IsValid())
+		{
+			OperationInProgress.Pin()->SetCompletionState(SNotificationItem::CS_Pending);
+		}
+	}
+}
+
+// Remove the ongoing notification at the end of the operation
+void FNotification::RemoveInProgress()
+{
+	if (OperationInProgress.IsValid())
+	{
+		OperationInProgress.Pin()->ExpireAndFadeout();
+		OperationInProgress.Reset();
+	}
+}
+
+// Display a temporary success notification at the end of the operation
+void FNotification::DisplaySuccess(const FName& InOperationName)
+{
+	const FText NotificationText = FText::Format(
+		LOCTEXT("PlasticSourceControlOperation_Success", "{0} operation was successful."),
+		FText::FromName(InOperationName)
+	);
+
+	DisplaySuccess(NotificationText);
+}
+
+void FNotification::DisplaySuccess(const FText& InNotificationText)
+{
+	FNotificationInfo* Info = new FNotificationInfo(InNotificationText);
+	Info->ExpireDuration = 1.0f;
+	Info->bFireAndForget = true;
+	Info->bUseSuccessFailIcons = true;
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
+	Info->Image = FAppStyle::GetBrush(TEXT("NotificationList.SuccessImage"));
+#else
+	Info->Image = FEditorStyle::GetBrush(TEXT("NotificationList.SuccessImage"));
+#endif
+	FSlateNotificationManager::Get().QueueNotification(Info);
+	UE_LOG(LogSourceControl, Verbose, TEXT("%s"), *InNotificationText.ToString());
+}
+
+// Display a temporary failure notification at the end of the operation
+void FNotification::DisplayFailure(const FName& InOperationName)
+{
+	const FText NotificationText = FText::Format(
+		LOCTEXT("PlasticSourceControlOperation_Failure", "Error: {0} operation failed!"),
+		FText::FromName(InOperationName)
+	);
+
+	DisplayFailure(NotificationText);
+}
+
+void FNotification::DisplayFailure(const FText& InNotificationText)
+{
+	FNotificationInfo* Info = new FNotificationInfo(InNotificationText);
+	Info->ExpireDuration = 8.0f;
+	Info->bFireAndForget = true;
+	FSlateNotificationManager::Get().QueueNotification(Info);
+	UE_LOG(LogSourceControl, Error, TEXT("%s"), *InNotificationText.ToString());
+}
+
+#undef LOCTEXT_NAMESPACE

--- a/Source/PlasticSourceControl/Private/Notification.h
+++ b/Source/PlasticSourceControl/Private/Notification.h
@@ -1,0 +1,32 @@
+// Copyright (c) 2023 Unity Technologies
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+#include "ISourceControlModule.h"
+
+class FNotification
+{
+public:
+	// Create and display (resp. expire and remove) an in-progress notification for a long-running operation
+	// Note: UI main thread only
+	void DisplayInProgress(const FText& InOperationInProgressString);
+	void RemoveInProgress();
+
+	bool IsInProgress() const
+	{
+		return OperationInProgress.IsValid();
+	}
+
+	// Display a short fire-and-forget notification
+	// Note: thread safe methods of queuing a notification from any thread
+	static void DisplaySuccess(const FName& InOperationName);
+	static void DisplaySuccess(const FText& InNotificationText);
+	static void DisplayFailure(const FName& InOperationName);
+	static void DisplayFailure(const FText& InNotificationText);
+
+private:
+	/** Current long-running notification if any */
+	TWeakPtr<class SNotificationItem> OperationInProgress;
+};

--- a/Source/PlasticSourceControl/Private/PackageUtils.h
+++ b/Source/PlasticSourceControl/Private/PackageUtils.h
@@ -7,6 +7,10 @@
 namespace PackageUtils
 {
 	TArray<FString> AssetDateToFileNames(const TArray<FAssetData>& InAssetObjectPaths);
+
+	bool SaveDirtyPackages();
+	TArray<FString> ListAllPackages();
+
 	void UnlinkPackages(const TArray<FString>& InFiles);
 	void UnlinkPackagesInMainThread(const TArray<FString>& InFiles);
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "ISourceControlProvider.h"
+#include "Notification.h"
 #include "Runtime/Launch/Resources/Version.h"
 
 class FMenuBuilder;
@@ -62,11 +63,6 @@ private:
 	void ExecuteReleaseLocks(TArray<FAssetData> InAssetObjectPaths);
 	void ExecuteUnlock(const TArray<FAssetData>& InAssetObjectPaths, const bool bInRemove);
 
-	void DisplayInProgressNotification(const FText& InOperationInProgressString);
-	void RemoveInProgressNotification();
-	void DisplaySucessNotification(const FName& InOperationName);
-	void DisplayFailureNotification(const FName& InOperationName);
-
 private:
 	/** Tracks if the menu extension has been registered with the editor or not */
 	bool bHasRegistered = false;
@@ -75,8 +71,8 @@ private:
 	FDelegateHandle ViewMenuExtenderHandle;
 #endif
 
-	/** Current source control operation from extended menu if any */
-	TWeakPtr<class SNotificationItem> OperationInProgressNotification;
+	/** Ongoing notification for a long-running asynchronous source control operation, if any */
+	FNotification Notification;
 
 	/** Name of the menu extension going into the global Revision Control (on the toolbar at the bottom-right) */
 	static FName UnityVersionControlMainMenuOwnerName;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.h
@@ -34,9 +34,6 @@ public:
 private:
 	bool IsSourceControlConnected() const;
 
-	bool				SaveDirtyPackages();
-	TArray<FString>		ListAllPackages();
-
 #if ENGINE_MAJOR_VERSION == 4
 	void AddMenuExtension(FMenuBuilder& Menu);
 	void AddViewBranches(FMenuBuilder& Menu);

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
@@ -43,10 +43,7 @@ class FPlasticSyncAll final : public FSync
 {
 public:
 	// ISourceControlOperation interface
-	virtual FName GetName() const override
-	{
-		return "SyncAll";
-	}
+	virtual FName GetName() const override;
 
 	/** List of files updated by the operation */
 	TArray<FString> UpdatedFiles;
@@ -132,6 +129,25 @@ public:
 
 	// List of branches found
 	TArray<FPlasticSourceControlBranchRef> Branches;
+};
+
+
+/**
+ * Internal operation used to switch the workspace to another branch
+*/
+class FPlasticSwitchToBranch final : public ISourceControlOperation
+{
+public:
+	// ISourceControlOperation interface
+	virtual FName GetName() const override;
+
+	virtual FText GetInProgressString() const override;
+
+	// Branch to switch the workspace to
+	FString BranchName;
+
+	/** List of files updated by the operation */
+	TArray<FString> UpdatedFiles;
 };
 
 
@@ -371,8 +387,22 @@ public:
 	virtual bool Execute(class FPlasticSourceControlCommand& InCommand) override;
 	virtual bool UpdateStates() override;
 
-	// Current branch the workspace is on
+	// Current branch the workspace is on (at the end of the operation)
 	FString CurrentBranchName;
+};
+
+/** Switch workspace to another branch. */
+class FPlasticSwitchToBranchWorker final : public IPlasticSourceControlWorker
+{
+public:
+	explicit FPlasticSwitchToBranchWorker(FPlasticSourceControlProvider& InSourceControlProvider)
+		: IPlasticSourceControlWorker(InSourceControlProvider)
+	{}
+	virtual ~FPlasticSwitchToBranchWorker() = default;
+	// IPlasticSourceControlWorker interface
+	virtual FName GetName() const override;
+	virtual bool Execute(class FPlasticSourceControlCommand& InCommand) override;
+	virtual bool UpdateStates() override;
 };
 
 /** Plastic update the workspace to latest changes */

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -2396,6 +2396,42 @@ bool RunGetBranches(const FDateTime& InFromDate, TArray<FPlasticSourceControlBra
 	return bCommandSuccessful;
 }
 
+bool RunSwitchToBranch(const FString& InBranchName, TArray<FString>& OutUpdatedFiles, TArray<FString>& OutErrorMessages)
+{
+	bool bResult = false;
+
+	const FScopedTempFile TempFile;
+	TArray<FString> InfoMessages;
+	TArray<FString> Parameters;
+	Parameters.Add(FString::Printf(TEXT("--xml=\"%s\""), *TempFile.GetFilename()));
+	Parameters.Add(TEXT("--encoding=\"utf-8\""));
+	Parameters.Add(FString::Printf(TEXT("br:%s"), *InBranchName));
+	bResult = PlasticSourceControlUtils::RunCommand(TEXT("switch"), Parameters, TArray<FString>(), InfoMessages, OutErrorMessages);
+	if (bResult)
+	{
+		// Load and parse the result of the update command
+		FString Results;
+		if (FFileHelper::LoadFileToString(Results, *TempFile.GetFilename()))
+		{
+			FXmlFile XmlFile;
+			{
+				TRACE_CPUPROFILER_EVENT_SCOPE(PlasticSourceControlUtils::RunUpdate::FXmlFile::LoadFile);
+				bResult = XmlFile.LoadFile(Results, EConstructMethod::ConstructFromBuffer);
+			}
+			if (bResult)
+			{
+				bResult = ParseUpdateResults(XmlFile, OutUpdatedFiles);
+			}
+			else
+			{
+				UE_LOG(LogSourceControl, Error, TEXT("RunUpdate: XML parse error '%s'"), *XmlFile.GetLastError())
+			}
+		}
+	}
+
+	return bResult;
+}
+
 bool UpdateCachedStates(TArray<FPlasticSourceControlState>&& InStates)
 {
 	FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
@@ -219,11 +219,19 @@ void AddShelvedFileToChangelist(FPlasticSourceControlChangelistState& InOutChang
 
 /**
  * Run find "branches where date >= 'YYYY/MM/DD'" and parse the results.
- * @param	InFromDate				The list of branches
+ * @param	InFromDate				The date to search from
  * @param	OutBranches				The list of branches
  * @param	OutErrorMessages		Any errors (from StdErr) as an array per-line
  */
 bool RunGetBranches(const FDateTime& InFromDate, TArray<FPlasticSourceControlBranchRef>& OutBranches, TArray<FString>& OutErrorMessages);
+
+/**
+ * Run switch br:/name and parse the results.
+ * @param	InBranchName			The name of the branch to switch the workspace to
+ * @param	OutUpdatedFiles			The files that where updated
+ * @param	OutErrorMessages		Any errors (from StdErr) as an array per-line
+ */
+bool RunSwitchToBranch(const FString& InBranchName, TArray<FString>& OutUpdatedFiles, TArray<FString>& OutErrorMessages);
 
 /**
  * Helper function for various commands to update cached states.

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlWorkspaceCreation.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlWorkspaceCreation.cpp
@@ -35,11 +35,11 @@ void FPlasticSourceControlWorkspaceCreation::LaunchMakeWorkspaceOperation()
 	ECommandResult::Type Result = Provider.Execute(MakeWorkspaceOperation, TArray<FString>(), EConcurrency::Asynchronous, FSourceControlOperationComplete::CreateRaw(this, &FPlasticSourceControlWorkspaceCreation::OnMakeWorkspaceOperationComplete));
 	if (Result == ECommandResult::Succeeded)
 	{
-		DisplayInProgressNotification(MakeWorkspaceOperation->GetInProgressString());
+		Notification.DisplayInProgress(MakeWorkspaceOperation->GetInProgressString());
 	}
 	else
 	{
-		DisplayFailureNotification(MakeWorkspaceOperation->GetName());
+		FNotification::DisplayFailure(MakeWorkspaceOperation->GetName());
 	}
 }
 
@@ -67,16 +67,16 @@ void FPlasticSourceControlWorkspaceCreation::LaunchMarkForAddOperation()
 		ECommandResult::Type Result = Provider.Execute(MarkForAddOperation, ProjectFiles, EConcurrency::Asynchronous, FSourceControlOperationComplete::CreateRaw(this, &FPlasticSourceControlWorkspaceCreation::OnMarkForAddOperationComplete));
 		if (Result == ECommandResult::Succeeded)
 		{
-			DisplayInProgressNotification(MarkForAddOperation->GetInProgressString());
+			Notification.DisplayInProgress(MarkForAddOperation->GetInProgressString());
 		}
 		else
 		{
-			DisplayFailureNotification(MarkForAddOperation->GetName());
+			FNotification::DisplayFailure(MarkForAddOperation->GetName());
 		}
 	}
 	else
 	{
-		DisplayFailureNotification(MarkForAddOperation->GetName());
+		FNotification::DisplayFailure(MarkForAddOperation->GetName());
 	}
 }
 
@@ -98,11 +98,11 @@ void FPlasticSourceControlWorkspaceCreation::LaunchCheckInOperation()
 	ECommandResult::Type Result = Provider.Execute(CheckInOperation, ProjectFiles, EConcurrency::Asynchronous, FSourceControlOperationComplete::CreateRaw(this, &FPlasticSourceControlWorkspaceCreation::OnCheckInOperationComplete));
 	if (Result == ECommandResult::Succeeded)
 	{
-		DisplayInProgressNotification(CheckInOperation->GetInProgressString());
+		Notification.DisplayInProgress(CheckInOperation->GetInProgressString());
 	}
 	else
 	{
-		DisplayFailureNotification(CheckInOperation->GetName());
+		FNotification::DisplayFailure(CheckInOperation->GetName());
 	}
 }
 
@@ -115,69 +115,17 @@ void FPlasticSourceControlWorkspaceCreation::OnCheckInOperationComplete(const FS
 
 void FPlasticSourceControlWorkspaceCreation::OnSourceControlOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult)
 {
-	RemoveInProgressNotification();
+	Notification.RemoveInProgress();
 
 	// Report result with a notification
 	if (InResult == ECommandResult::Succeeded)
 	{
-		DisplaySuccessNotification(InOperation->GetName());
+		FNotification::DisplaySuccess(InOperation->GetName());
 	}
 	else
 	{
-		DisplayFailureNotification(InOperation->GetName());
+		FNotification::DisplayFailure(InOperation->GetName());
 	}
-}
-
-// Display an ongoing notification during the whole operation
-void FPlasticSourceControlWorkspaceCreation::DisplayInProgressNotification(const FText& InOperationInProgressString)
-{
-	if (!OperationInProgressNotification.IsValid())
-	{
-		FNotificationInfo Info(InOperationInProgressString);
-		Info.bFireAndForget = false;
-		Info.ExpireDuration = 0.0f;
-		Info.FadeOutDuration = 1.0f;
-		OperationInProgressNotification = FSlateNotificationManager::Get().AddNotification(Info);
-		if (OperationInProgressNotification.IsValid())
-		{
-			OperationInProgressNotification.Pin()->SetCompletionState(SNotificationItem::CS_Pending);
-		}
-	}
-}
-
-// Remove the ongoing notification at the end of the operation
-void FPlasticSourceControlWorkspaceCreation::RemoveInProgressNotification()
-{
-	if (OperationInProgressNotification.IsValid())
-	{
-		OperationInProgressNotification.Pin()->ExpireAndFadeout();
-		OperationInProgressNotification.Reset();
-	}
-}
-
-// Display a temporary success notification at the end of the operation
-void FPlasticSourceControlWorkspaceCreation::DisplaySuccessNotification(const FName& InOperationName)
-{
-	const FText NotificationText = FText::Format(LOCTEXT("InitWorkspace_Success", "{0} operation was successful!"), FText::FromName(InOperationName));
-	FNotificationInfo Info(NotificationText);
-	Info.bUseSuccessFailIcons = true;
-#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
-	Info.Image = FAppStyle::GetBrush(TEXT("NotificationList.SuccessImage"));
-#else
-	Info.Image = FEditorStyle::GetBrush(TEXT("NotificationList.SuccessImage"));
-#endif
-	FSlateNotificationManager::Get().AddNotification(Info);
-	UE_LOG(LogSourceControl, Verbose, TEXT("%s"), *NotificationText.ToString());
-}
-
-// Display a temporary failure notification at the end of the operation
-void FPlasticSourceControlWorkspaceCreation::DisplayFailureNotification(const FName& InOperationName)
-{
-	const FText NotificationText = FText::Format(LOCTEXT("InitWorkspace_Failure", "Error: {0} operation failed!"), FText::FromName(InOperationName));
-	FNotificationInfo Info(NotificationText);
-	Info.ExpireDuration = 8.0f;
-	FSlateNotificationManager::Get().AddNotification(Info);
-	UE_LOG(LogSourceControl, Error, TEXT("%s"), *NotificationText.ToString());
 }
 
 /** Path to the "ignore.conf" file */

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlWorkspaceCreation.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlWorkspaceCreation.h
@@ -4,6 +4,8 @@
 
 #include "CoreMinimal.h"
 
+#include "Notification.h"
+
 #include "ISourceControlProvider.h"
 #include "ISourceControlOperation.h"
 
@@ -37,13 +39,8 @@ private:
 	/** Generic notification handler */
 	void OnSourceControlOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
 
-	/** Asynchronous operation progress notifications */
-	TWeakPtr<class SNotificationItem> OperationInProgressNotification;
-
-	void DisplayInProgressNotification(const FText& InOperationInProgressString);
-	void RemoveInProgressNotification();
-	void DisplaySuccessNotification(const FName& InOperationName);
-	void DisplayFailureNotification(const FName& InOperationName);
+	/** Ongoing notification for a long-running asynchronous source control operation, if any */
+	FNotification Notification;
 
 	const FString GetIgnoreFileName() const;
 	TArray<FString> GetProjectFiles() const;

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
@@ -590,11 +590,7 @@ void SPlasticSourceControlBranchesWidget::OnGetBranchesOperationComplete(const F
 	TSharedRef<FPlasticGetBranches, ESPMode::ThreadSafe> OperationGetBranches = StaticCastSharedRef<FPlasticGetBranches>(InOperation);
 	SourceControlBranches = MoveTemp(OperationGetBranches->Branches);
 
-	FString NewCurrentBranchName = FPlasticSourceControlModule::Get().GetProvider().GetBranchName();
-	if (NewCurrentBranchName != CurrentBranchName)
-	{
-		CurrentBranchName = MoveTemp(NewCurrentBranchName);
-	}
+	CurrentBranchName = FPlasticSourceControlModule::Get().GetProvider().GetBranchName();
 
 	EndRefreshStatus();
 	OnRefreshUI();

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
@@ -113,14 +113,6 @@ void SPlasticSourceControlBranchesWidget::Construct(const FArguments& InArgs)
 					.Margin(FMargin(5.f, 0.f))
 				]
 				+SHorizontalBox::Slot()
-				.HAlign(HAlign_Left)
-				.AutoWidth()
-				[
-					SNew(STextBlock)
-					.Text_Lambda([this]() { return FText::AsNumber(BranchRows.Num()); })
-					.ToolTipText(LOCTEXT("PlasticBranchesNumber_Tooltip", "Number of branches displayed after filtering by date and by search keywords."))
-				]
-				+SHorizontalBox::Slot()
 				.HAlign(HAlign_Right)
 				[
 					SNew(STextBlock)

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
@@ -683,6 +683,10 @@ void SPlasticSourceControlBranchesWidget::OnSwitchToBranchOperationComplete(cons
 {
 	TRACE_CPUPROFILER_EVENT_SCOPE(SPlasticSourceControlBranchesWidget::OnSwitchToBranchOperationComplete);
 
+	// Reload packages that where updated by the SwitchToBranch operation (and the current map if needed)
+	TSharedRef<FPlasticSwitchToBranch, ESPMode::ThreadSafe> Operation = StaticCastSharedRef<FPlasticSwitchToBranch>(InOperation);
+	PackageUtils::ReloadPackages(Operation->UpdatedFiles);
+
 	// Ask for a full refresh of the list of branches (and don't call EndRefreshStatus() yet)
 	bShouldRefresh = true;
 

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
@@ -545,8 +545,11 @@ void SPlasticSourceControlBranchesWidget::Tick(const FGeometry& AllottedGeometry
 
 void SPlasticSourceControlBranchesWidget::StartRefreshStatus()
 {
-	bIsRefreshing = true;
-	RefreshStatusStartSecs = FPlatformTime::Seconds();
+	if (!bIsRefreshing)
+	{
+		bIsRefreshing = true;
+		RefreshStatusStartSecs = FPlatformTime::Seconds();
+	}
 }
 
 void SPlasticSourceControlBranchesWidget::TickRefreshStatus(double InDeltaTime)
@@ -558,6 +561,7 @@ void SPlasticSourceControlBranchesWidget::TickRefreshStatus(double InDeltaTime)
 void SPlasticSourceControlBranchesWidget::EndRefreshStatus()
 {
 	bIsRefreshing = false;
+	RefreshStatus = FText::GetEmpty();
 }
 
 void SPlasticSourceControlBranchesWidget::RequestBranchesRefresh()
@@ -577,17 +581,6 @@ void SPlasticSourceControlBranchesWidget::RequestBranchesRefresh()
 
 	FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
 	Provider.Execute(GetBranchesOperation, EConcurrency::Asynchronous, FSourceControlOperationComplete::CreateSP(this, &SPlasticSourceControlBranchesWidget::OnGetBranchesOperationComplete));
-	OnStartSourceControlOperation(GetBranchesOperation, LOCTEXT("SourceControl_UpdatingChangelist", "Updating branches..."));
-}
-
-void SPlasticSourceControlBranchesWidget::OnStartSourceControlOperation(const FSourceControlOperationRef InOperation, const FText& InMessage)
-{
-	RefreshStatus = InMessage;
-}
-
-void SPlasticSourceControlBranchesWidget::OnEndSourceControlOperation(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult)
-{
-	RefreshStatus = FText::GetEmpty();
 }
 
 void SPlasticSourceControlBranchesWidget::OnGetBranchesOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult)
@@ -603,7 +596,6 @@ void SPlasticSourceControlBranchesWidget::OnGetBranchesOperationComplete(const F
 		CurrentBranchName = MoveTemp(NewCurrentBranchName);
 	}
 
-	OnEndSourceControlOperation(InOperation, InResult);
 	EndRefreshStatus();
 	OnRefreshUI();
 }

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
@@ -517,7 +517,7 @@ void SPlasticSourceControlBranchesWidget::SortBranchView()
 
 void SPlasticSourceControlBranchesWidget::Tick(const FGeometry& AllottedGeometry, const double InCurrentTime, const float InDeltaTime)
 {
-	if (!ISourceControlModule::Get().IsEnabled() && (!FPlasticSourceControlModule::Get().GetProvider().IsAvailable()))
+	if (!ISourceControlModule::Get().IsEnabled() || (!FPlasticSourceControlModule::Get().GetProvider().IsAvailable()))
 	{
 		return;
 	}
@@ -562,7 +562,7 @@ void SPlasticSourceControlBranchesWidget::EndRefreshStatus()
 
 void SPlasticSourceControlBranchesWidget::RequestBranchesRefresh()
 {
-	if (!ISourceControlModule::Get().IsEnabled() && (!FPlasticSourceControlModule::Get().GetProvider().IsAvailable()))
+	if (!ISourceControlModule::Get().IsEnabled() || (!FPlasticSourceControlModule::Get().GetProvider().IsAvailable()))
 	{
 		return;
 	}

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
@@ -3,6 +3,9 @@
 #pragma once
 
 #include "CoreMinimal.h"
+
+#include "Notification.h"
+
 #include "Misc/TextFilter.h"
 #include "Widgets/SCompoundWidget.h"
 #include "Widgets/Views/SListView.h"
@@ -57,6 +60,7 @@ private:
 
 	/** Source control callbacks */
 	void OnGetBranchesOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
+	void OnSwitchToBranchOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
 	void OnSourceControlProviderChanged(ISourceControlProvider& OldProvider, ISourceControlProvider& NewProvider);
 
 	SListView<FPlasticSourceControlBranchRef>* GetListView() const
@@ -82,6 +86,9 @@ private:
 	double RefreshStatusStartSecs;
 
 	FString CurrentBranchName;
+
+	/** Ongoing notification for a long-running asynchronous source control operation, if any */
+	FNotification Notification;
 
 	TSharedPtr<SListView<FPlasticSourceControlBranchRef>> BranchesListView;
 	TSharedPtr<TTextFilter<const FPlasticSourceControlBranch&>> SearchTextFilter;

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
@@ -50,8 +50,6 @@ private:
 	void EndRefreshStatus();
 
 	void RequestBranchesRefresh();
-	void OnStartSourceControlOperation(const FSourceControlOperationRef InOperation, const FText& InMessage);
-	void OnEndSourceControlOperation(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
 
 	/** Source control callbacks */
 	void OnGetBranchesOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
@@ -43,19 +43,19 @@ private:
 	EColumnSortMode::Type GetColumnSortMode(const FName InColumnId) const;
 	void OnColumnSortModeChanged(const EColumnSortPriority::Type InSortPriority, const FName& InColumnId, const EColumnSortMode::Type InSortMode);
 
+	void SortBranchView();
+
 	void StartRefreshStatus();
 	void TickRefreshStatus(double InDeltaTime);
 	void EndRefreshStatus();
 
 	void RequestBranchesRefresh();
-	void OnBranchesUpdated(const TSharedRef<ISourceControlOperation, ESPMode::ThreadSafe>& InOperation, ECommandResult::Type InType);
-	void OnStartSourceControlOperation(const TSharedRef<ISourceControlOperation, ESPMode::ThreadSafe> InOperation, const FText& InMessage);
-	void OnEndSourceControlOperation(const TSharedRef<ISourceControlOperation, ESPMode::ThreadSafe>& InOperation, ECommandResult::Type InType);
+	void OnStartSourceControlOperation(const FSourceControlOperationRef InOperation, const FText& InMessage);
+	void OnEndSourceControlOperation(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
 
 	/** Source control callbacks */
+	void OnGetBranchesOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
 	void OnSourceControlProviderChanged(ISourceControlProvider& OldProvider, ISourceControlProvider& NewProvider);
-
-	void SortBranchView();
 
 	SListView<FPlasticSourceControlBranchRef>* GetListView() const
 	{

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
@@ -44,6 +44,10 @@ private:
 	void OnColumnSortModeChanged(const EColumnSortPriority::Type InSortPriority, const FName& InColumnId, const EColumnSortMode::Type InSortMode);
 
 	void SortBranchView();
+	FString GetSelectedBranch();
+
+	TSharedPtr<SWidget> OnOpenContextMenu();
+	void OnSwitchToBranchClicked(FString InBranchName);
 
 	void StartRefreshStatus();
 	void TickRefreshStatus(double InDeltaTime);


### PR DESCRIPTION
![image](https://github.com/PlasticSCM/UEPlasticPlugin/assets/101874327/1c4c1a1b-8311-4523-9b4d-b04b3629cf81)

- Minor rename and ordering of source control callbacks
- Fix boolean logic to check if the source control provider is enabled and available
- Improvement of RefreshStatus to replace OnStart/OnEndSourceControlOperation()
- Don't display the number of branches, it's confusing and doesn't bring any value
- Add a context menu -> Switch workspace to branch
- Move duplicated notification methods into a new FNotification class
- Move SaveDirtyPackages() and ListAllPackages() from FPlasticSourceControlMenu to PackageUtils
- New PlasticSourceControlUtils RunSwitchToBranch()
- New SwitchToBranch operation and Worker
- Execute the switch operation from the context menu, asynchronously, with an ongoing notification while it runs
- ReloadPackages & current map at the end of the switch branch operation

