### PR TITLE
Add a merge branch operation

### DIFF
--- a/Source/PlasticSourceControl/Private/Notification.cpp
+++ b/Source/PlasticSourceControl/Private/Notification.cpp
@@ -2,8 +2,8 @@
 
 #include "Notification.h"
 
-#include "Widgets/Notifications/SNotificationList.h"
 #include "Framework/Notifications/NotificationManager.h"
+#include "Widgets/Notifications/SNotificationList.h"
 
 #include "Runtime/Launch/Resources/Version.h"
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
@@ -55,13 +55,13 @@ void FNotification::DisplaySuccess(const FName& InOperationName)
 void FNotification::DisplaySuccess(const FText& InNotificationText)
 {
 	FNotificationInfo* Info = new FNotificationInfo(InNotificationText);
-	Info->ExpireDuration = 1.0f;
+	Info->ExpireDuration = 3.0f;
 	Info->bFireAndForget = true;
 	Info->bUseSuccessFailIcons = true;
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
-	Info->Image = FAppStyle::GetBrush(TEXT("NotificationList.SuccessImage"));
+	Info->Image = FAppStyle::GetBrush(TEXT("Icons.SuccessWithColor.Large"));
 #else
-	Info->Image = FEditorStyle::GetBrush(TEXT("NotificationList.SuccessImage"));
+	Info->Image = FEditorStyle::GetBrush(TEXT("NotificationList.FailImage"));
 #endif
 	FSlateNotificationManager::Get().QueueNotification(Info);
 	UE_LOG(LogSourceControl, Verbose, TEXT("%s"), *InNotificationText.ToString());
@@ -81,8 +81,18 @@ void FNotification::DisplayFailure(const FName& InOperationName)
 void FNotification::DisplayFailure(const FText& InNotificationText)
 {
 	FNotificationInfo* Info = new FNotificationInfo(InNotificationText);
-	Info->ExpireDuration = 8.0f;
+	Info->ExpireDuration = 10.0f;
 	Info->bFireAndForget = true;
+	Info->bUseSuccessFailIcons = true;
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
+	Info->Image = FAppStyle::GetBrush(TEXT("Icons.ErrorWithColor.Large"));
+#else
+	Info->Image = FEditorStyle::GetBrush(TEXT("NotificationList.SuccessImage"));
+#endif
+	// Provide a link to easily open the Output Log
+	Info->Hyperlink = FSimpleDelegate::CreateLambda([]() { FGlobalTabmanager::Get()->TryInvokeTab(FName("OutputLog")); });
+	Info->HyperlinkText = LOCTEXT("ShowOutputLogHyperlink", "Show Output Log");
+
 	FSlateNotificationManager::Get().QueueNotification(Info);
 	UE_LOG(LogSourceControl, Error, TEXT("%s"), *InNotificationText.ToString());
 }

--- a/Source/PlasticSourceControl/Private/Notification.cpp
+++ b/Source/PlasticSourceControl/Private/Notification.cpp
@@ -5,6 +5,10 @@
 #include "Framework/Notifications/NotificationManager.h"
 #include "Widgets/Notifications/SNotificationList.h"
 
+#include "ISourceControlModule.h"
+#include "ISourceControlOperation.h"
+#include "SourceControlOperationBase.h"
+
 #include "Runtime/Launch/Resources/Version.h"
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
 #include "Styling/AppStyle.h"
@@ -41,7 +45,36 @@ void FNotification::RemoveInProgress()
 	}
 }
 
+void FNotification::DisplayResult(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult)
+{
+	DisplayResult(StaticCastSharedRef<FSourceControlOperationBase>(InOperation).Get(), InResult);
+}
+
+void FNotification::DisplayResult(const FSourceControlOperationBase& InOperation, ECommandResult::Type InResult)
+{
+	if (InResult == ECommandResult::Succeeded)
+	{
+		FNotification::DisplaySuccess(InOperation);
+	}
+	else
+	{
+		FNotification::DisplayFailure(InOperation);
+	}
+}
+
 // Display a temporary success notification at the end of the operation
+void FNotification::DisplaySuccess(const FSourceControlOperationBase& InOperation)
+{
+	if (InOperation.GetResultInfo().InfoMessages.Num() > 0)
+	{
+		DisplayFailure(InOperation.GetResultInfo().InfoMessages[0]);
+	}
+	else
+	{
+		DisplaySuccess(InOperation.GetName());
+	}
+}
+
 void FNotification::DisplaySuccess(const FName& InOperationName)
 {
 	const FText NotificationText = FText::Format(
@@ -68,6 +101,18 @@ void FNotification::DisplaySuccess(const FText& InNotificationText)
 }
 
 // Display a temporary failure notification at the end of the operation
+void FNotification::DisplayFailure(const FSourceControlOperationBase& InOperation)
+{
+	if (InOperation.GetResultInfo().ErrorMessages.Num() > 0)
+	{
+		DisplayFailure(InOperation.GetResultInfo().ErrorMessages[0]);
+	}
+	else
+	{
+		DisplayFailure(InOperation.GetName());
+	}
+}
+
 void FNotification::DisplayFailure(const FName& InOperationName)
 {
 	const FText NotificationText = FText::Format(

--- a/Source/PlasticSourceControl/Private/Notification.h
+++ b/Source/PlasticSourceControl/Private/Notification.h
@@ -4,7 +4,10 @@
 
 #include "CoreMinimal.h"
 
-#include "ISourceControlModule.h"
+#include "ISourceControlProvider.h"
+
+class ISourceControlOperation;
+class FSourceControlOperationBase;
 
 class FNotification
 {
@@ -21,8 +24,14 @@ public:
 
 	// Display a short fire-and-forget notification
 	// Note: thread safe methods of queuing a notification from any thread
+	static void DisplayResult(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
+	static void DisplayResult(const FSourceControlOperationBase& InOperation, ECommandResult::Type InResult);
+
+	static void DisplaySuccess(const FSourceControlOperationBase& InOperation);
 	static void DisplaySuccess(const FName& InOperationName);
 	static void DisplaySuccess(const FText& InNotificationText);
+
+	static void DisplayFailure(const FSourceControlOperationBase& InOperation);
 	static void DisplayFailure(const FName& InOperationName);
 	static void DisplayFailure(const FText& InNotificationText);
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
@@ -394,7 +394,7 @@ void FPlasticSourceControlMenu::RevertAllClicked()
 	{
 		// Ask the user before reverting all!
 		const FText DialogText(LOCTEXT("SourceControlMenu_AskRevertAll", "Revert all modifications into the workspace?"));
-		const EAppReturnType::Type Choice = FMessageDialog::Open(EAppMsgType::OkCancel, DialogText);
+		const EAppReturnType::Type Choice = FMessageDialog::Open(EAppMsgCategory::Warning, EAppMsgType::OkCancel, DialogText);
 		if (Choice == EAppReturnType::Ok)
 		{
 			const bool bSaved = PackageUtils::SaveDirtyPackages();
@@ -441,7 +441,7 @@ void FPlasticSourceControlMenu::SwitchToPartialWorkspaceClicked()
 		// Ask the user before switching to Partial Workspace. It's not possible to switch back with local changes!
 		const FText DialogText(LOCTEXT("SourceControlMenu_AskSwitchToPartialWorkspace", "Switch to Gluon partial workspace?\n"
 			"Please note that, in order to switch back to a regular workspace you will need to undo all local changes."));
-		const EAppReturnType::Type Choice = FMessageDialog::Open(EAppMsgType::OkCancel, DialogText);
+		const EAppReturnType::Type Choice = FMessageDialog::Open(EAppMsgCategory::Info, EAppMsgType::OkCancel, DialogText);
 		if (Choice == EAppReturnType::Ok)
 		{
 			// Launch a "SwitchToPartialWorkspace" Operation

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
@@ -304,7 +304,7 @@ void FPlasticSourceControlMenu::ExecuteUnlock(const TArray<FAssetData>& InAssetO
 		else
 		{
 			// Report failure with a notification (but nothing need to be reloaded since no local change is expected)
-			FNotification::DisplayFailure(UnlockOperation->GetName());
+			FNotification::DisplayFailure(UnlockOperation.Get());
 		}
 	}
 	else
@@ -343,7 +343,7 @@ void FPlasticSourceControlMenu::SyncProjectClicked()
 			else
 			{
 				// Report failure with a notification (but nothing need to be reloaded since no local change is expected)
-				FNotification::DisplayFailure(SyncOperation->GetName());
+				FNotification::DisplayFailure(SyncOperation.Get());
 			}
 		}
 		else
@@ -377,7 +377,7 @@ void FPlasticSourceControlMenu::RevertUnchangedClicked()
 		else
 		{
 			// Report failure with a notification
-			FNotification::DisplayFailure(RevertUnchangedOperation->GetName());
+			FNotification::DisplayFailure(RevertUnchangedOperation.Get());
 		}
 	}
 	else
@@ -415,7 +415,7 @@ void FPlasticSourceControlMenu::RevertAllClicked()
 				else
 				{
 					// Report failure with a notification (but nothing need to be reloaded since no local change is expected)
-					FNotification::DisplayFailure(RevertAllOperation->GetName());
+					FNotification::DisplayFailure(RevertAllOperation.Get());
 				}
 			}
 			else
@@ -456,7 +456,7 @@ void FPlasticSourceControlMenu::SwitchToPartialWorkspaceClicked()
 			else
 			{
 				// Report failure with a notification
-				FNotification::DisplayFailure(SwitchOperation->GetName());
+				FNotification::DisplayFailure(SwitchOperation.Get());
 			}
 		}
 	}
@@ -553,15 +553,7 @@ void FPlasticSourceControlMenu::OnSourceControlOperationComplete(const FSourceCo
 {
 	Notification.RemoveInProgress();
 
-	// Report result with a notification
-	if (InResult == ECommandResult::Succeeded)
-	{
-		FNotification::DisplaySuccess(InOperation->GetName());
-	}
-	else
-	{
-		FNotification::DisplayFailure(InOperation->GetName());
-	}
+	FNotification::DisplayResult(InOperation, InResult);
 }
 
 // TODO rework the menus with sub-menus like in the POC branch

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -1094,12 +1094,20 @@ bool FPlasticSwitchToBranchWorker::Execute(FPlasticSourceControlCommand& InComma
 	check(InCommand.Operation->GetName() == GetName());
 	TSharedRef<FPlasticSwitchToBranch, ESPMode::ThreadSafe> Operation = StaticCastSharedRef<FPlasticSwitchToBranch>(InCommand.Operation);
 
-	return PlasticSourceControlUtils::RunSwitchToBranch(Operation->BranchName, Operation->UpdatedFiles, InCommand.ErrorMessages);
+	InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunSwitchToBranch(Operation->BranchName, Operation->UpdatedFiles, InCommand.ErrorMessages);
+
+	// now update the status of the updated files
+	if (Operation->UpdatedFiles.Num())
+	{
+		InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunUpdateStatus(Operation->UpdatedFiles, PlasticSourceControlUtils::EStatusSearchType::ControlledOnly, false, InCommand.ErrorMessages, States, InCommand.ChangesetNumber, InCommand.BranchName);
+	}
+
+	return InCommand.bCommandSuccessful;
 }
 
 bool FPlasticSwitchToBranchWorker::UpdateStates()
 {
-	return false;
+	return PlasticSourceControlUtils::UpdateCachedStates(MoveTemp(States));
 }
 
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -1147,6 +1147,11 @@ bool FPlasticMergeBranchWorker::Execute(FPlasticSourceControlCommand& InCommand)
 
 bool FPlasticMergeBranchWorker::UpdateStates()
 {
+#if ENGINE_MAJOR_VERSION == 5
+	// Update the Default changelist.
+	UpdateChangelistState(GetProvider(), FPlasticSourceControlChangelist::DefaultChangelist, States);
+#endif
+
 	return PlasticSourceControlUtils::UpdateCachedStates(MoveTemp(States));
 }
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
@@ -152,6 +152,25 @@ public:
 
 
 /**
+ * Internal operation used to merge a branch into the current branch
+*/
+class FPlasticMergeBranch final : public FSourceControlOperationBase
+{
+public:
+	// ISourceControlOperation interface
+	virtual FName GetName() const override;
+
+	virtual FText GetInProgressString() const override;
+
+	// Branch to switch the workspace to
+	FString BranchName;
+
+	/** List of files updated by the operation */
+	TArray<FString> UpdatedFiles;
+};
+
+
+/**
  * Internal operation used to create a branch
 */
 class FPlasticCreateBranch final : public FSourceControlOperationBase
@@ -446,6 +465,24 @@ public:
 		: IPlasticSourceControlWorker(InSourceControlProvider)
 	{}
 	virtual ~FPlasticSwitchToBranchWorker() = default;
+	// IPlasticSourceControlWorker interface
+	virtual FName GetName() const override;
+	virtual bool Execute(class FPlasticSourceControlCommand& InCommand) override;
+	virtual bool UpdateStates() override;
+
+public:
+	/** Temporary states for results */
+	TArray<FPlasticSourceControlState> States;
+};
+
+/** Merge a branch to the current branch. */
+class FPlasticMergeBranchWorker final : public IPlasticSourceControlWorker
+{
+public:
+	explicit FPlasticMergeBranchWorker(FPlasticSourceControlProvider& InSourceControlProvider)
+		: IPlasticSourceControlWorker(InSourceControlProvider)
+	{}
+	virtual ~FPlasticMergeBranchWorker() = default;
 	// IPlasticSourceControlWorker interface
 	virtual FName GetName() const override;
 	virtual bool Execute(class FPlasticSourceControlCommand& InCommand) override;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
@@ -450,6 +450,10 @@ public:
 	virtual FName GetName() const override;
 	virtual bool Execute(class FPlasticSourceControlCommand& InCommand) override;
 	virtual bool UpdateStates() override;
+
+public:
+	/** Temporary states for results */
+	TArray<FPlasticSourceControlState> States;
 };
 
 /** Create a new child branch. */

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.cpp
@@ -881,7 +881,10 @@ static bool ParseUpdateResults(const FXmlFile& InXmlResult, TArray<FString>& Out
 		{
 			FString Filename = PathNode->GetContent();
 			FPaths::NormalizeFilename(Filename);
-			OutFiles.Add(Filename);
+			if (!OutFiles.Contains(Filename))
+			{
+				OutFiles.Add(Filename);
+			}
 		}
 	}
 
@@ -932,7 +935,10 @@ bool ParseUpdateResults(const TArray<FString>& InResults, TArray<FString>& OutFi
 
 		FString Filename = Result.RightChop(PrefixLen);
 		FPaths::NormalizeFilename(Filename);
-		OutFiles.Add(Filename);
+		if (!OutFiles.Contains(Filename))
+		{
+			OutFiles.Add(Filename);
+		}
 	}
 
 	return true;
@@ -1144,7 +1150,7 @@ M "Content\NewFolder\BP_ControlledUnchanged.uasset" "Content\NewFolder\BP_Rename
 */
 bool ParseShelveDiffResult(const FString InWorkspaceRoot, TArray<FString>&& InResults, FPlasticSourceControlChangelistState& InOutChangelistsState)
 {
-	bool bCommandSuccessful = true;
+	bool bResult = true;
 
 	InOutChangelistsState.ShelvedFiles.Reset(InResults.Num());
 	for (FString& Result : InResults)
@@ -1174,11 +1180,11 @@ bool ParseShelveDiffResult(const FString InWorkspaceRoot, TArray<FString>&& InRe
 		}
 		else
 		{
-			bCommandSuccessful = false;
+			bResult = false;
 		}
 	}
 
-	return bCommandSuccessful;
+	return bResult;
 }
 
 /**
@@ -1282,7 +1288,7 @@ M;-1;"Content\ThirdPerson\Blueprints\BP_ThirdPersonCharacterRenamed.uasset"
 */
 bool ParseShelveDiffResults(const FString InWorkspaceRoot, TArray<FString>&& InResults, TArray<FPlasticSourceControlRevision>& OutBaseRevisions)
 {
-	bool bCommandSuccessful = true;
+	bool bResult = true;
 
 	OutBaseRevisions.Reset(InResults.Num());
 	for (FString& InResult : InResults)
@@ -1321,11 +1327,11 @@ bool ParseShelveDiffResults(const FString InWorkspaceRoot, TArray<FString>&& InR
 		}
 		else
 		{
-			bCommandSuccessful = false;
+			bResult = false;
 		}
 	}
 
-	return bCommandSuccessful;
+	return bResult;
 }
 
 /**

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.cpp
@@ -264,7 +264,6 @@ void ParseFileStatusResult(TArray<FString>&& InFiles, const TArray<FString>& InR
 	TRACE_CPUPROFILER_EVENT_SCOPE(PlasticSourceControlParsers::ParseFileStatusResult);
 
 	FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
-	const FString& WorkspaceRoot = Provider.GetPathToWorkspaceRoot();
 	const bool bUsesCheckedOutChanged = Provider.GetPlasticScmVersion() >= PlasticSourceControlVersions::StatusIsCheckedOutChanged;
 
 	// Parse the list of status results in a map indexed by absolute filename
@@ -1564,6 +1563,8 @@ static bool ParseMergeResults(const FXmlFile& InXmlResult, TArray<FString>& OutF
 	static const FString Path(TEXT("Path"));
 	static const FString DstPath(TEXT("DstPath"));
 
+	const FString WorkspaceRoot = FPlasticSourceControlModule::Get().GetProvider().GetPathToWorkspaceRoot().LeftChop(1);
+
 	const FXmlNode* MergeNode = InXmlResult.GetRootNode();
 	if (MergeNode == nullptr || MergeNode->GetTag() != Merge)
 	{
@@ -1580,7 +1581,7 @@ static bool ParseMergeResults(const FXmlFile& InXmlResult, TArray<FString>& OutF
 				const FString PathName = MergeType == Moved ? DstPath : Path;
 				if (const FXmlNode* PathNode = MergeItemNode->FindChildNode(PathName))
 				{
-					FString Filename = PathNode->GetContent();
+					FString Filename = FPaths::Combine(WorkspaceRoot, PathNode->GetContent());
 					FPaths::NormalizeFilename(Filename);
 					if (!OutFiles.Contains(Filename))
 					{

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.h
@@ -93,5 +93,6 @@ bool ParseShelvesResult(const FString& InResults, FString& OutComment, FDateTime
 
 bool ParseBranchesResults(const FString& InResults, TArray<FPlasticSourceControlBranchRef>& OutBranches);
 
+bool ParseMergeResults(const FString& InResult, TArray<FString>& OutFiles);
 
 } // namespace PlasticSourceControlParsers

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
@@ -623,12 +623,12 @@ void FPlasticSourceControlProvider::UpdateWorkspaceStatus(const class FPlasticSo
 					Args.Add(TEXT("OldestSupportedPlasticScmVersion"), FText::FromString(PlasticSourceControlVersions::OldestSupported.String));
 					const FText UnsuportedVersionWarning = FText::Format(LOCTEXT("Plastic_UnsuportedVersion", "Unity Version Control {PlasticScmVersion} is not supported anymore by this plugin.\nUnity Version Control {OldestSupportedPlasticScmVersion} or a more recent version is required.\nPlease upgrade to the latest version."), Args);
 					FMessageLog("SourceControl").Warning(UnsuportedVersionWarning);
-					FMessageDialog::Open(EAppMsgType::Ok, UnsuportedVersionWarning);
+					FMessageDialog::Open(EAppMsgCategory::Warning, EAppMsgType::Ok, UnsuportedVersionWarning);
 				}
 			}
 			else if (InCommand.ErrorMessages.Num() > 0)
 			{
-				FMessageDialog::Open(EAppMsgType::Ok, FText::FromString(InCommand.ErrorMessages[0]));
+				FMessageDialog::Open(EAppMsgCategory::Error, EAppMsgType::Ok, FText::FromString(InCommand.ErrorMessages[0]));
 			}
 		}
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -1042,19 +1042,7 @@ bool RunMergeBranch(const FString& InBranchName, TArray<FString>& OutUpdatedFile
 		FString Results;
 		if (FFileHelper::LoadFileToString(Results, *TempFile.GetFilename()))
 		{
-			FXmlFile XmlFile;
-			{
-				TRACE_CPUPROFILER_EVENT_SCOPE(PlasticSourceControlUtils::RunUpdate::FXmlFile::LoadFile);
-				bResult = XmlFile.LoadFile(Results, EConstructMethod::ConstructFromBuffer);
-			}
-			if (bResult)
-			{
-				bResult = ParseUpdateResults(XmlFile, OutUpdatedFiles);
-			}
-			else
-			{
-				UE_LOG(LogSourceControl, Error, TEXT("RunUpdate: XML parse error '%s'"), *XmlFile.GetLastError())
-			}
+			PlasticSourceControlParsers::ParseMergeResults(Results, OutUpdatedFiles);
 		}
 	}
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
@@ -245,6 +245,14 @@ bool RunGetBranches(const FDateTime& InFromDate, TArray<FPlasticSourceControlBra
 bool RunSwitchToBranch(const FString& InBranchName, TArray<FString>& OutUpdatedFiles, TArray<FString>& OutErrorMessages);
 
 /**
+ * Run merge br:/name and parse the results.
+ * @param	InBranchName			The name of the branch to merge to the current branch
+ * @param	OutUpdatedFiles			The files that where updated
+ * @param	OutErrorMessages		Any errors (from StdErr) as an array per-line
+ */
+bool RunMergeBranch(const FString& InBranchName, TArray<FString>& OutUpdatedFiles, TArray<FString>& OutErrorMessages);
+
+/**
  * Run branch create <name> --commentsfile
  * @param	InBranchName			The name of the branch to create
  * @param	InComment				The comment for the new branch to create

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlVersions.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlVersions.h
@@ -38,8 +38,12 @@ namespace PlasticSourceControlVersions
 	// https://plasticscm.com/download/releasenotes/11.0.16.7709 (2023/01/12)
 	static const FSoftwareVersion StatusIsCheckedOutChanged(TEXT("11.0.16.7709"));
 
-	// 11.0.16.8101 Introducing Smart Locks (2023/07/06)
-	// https://www.plasticscm.com/download/releasenotes/11.0.16.8101
+	// 11.0.16.7726 add support for merge --xml
+	// https://plasticscm.com/download/releasenotes/11.0.16.7726 (2023/01/19)
+	static const FSoftwareVersion MergeXml(TEXT("11.0.16.7726"));
+
+	// 11.0.16.8101 Introducing Smart Locks
+	// https://plasticscm.com/download/releasenotes/11.0.16.8101 (2023/07/06)
 	static const FSoftwareVersion SmartLocks(TEXT("11.0.16.8101"));
 
 } // namespace PlasticSourceControlVersions

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlWorkspaceCreation.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlWorkspaceCreation.cpp
@@ -39,7 +39,7 @@ void FPlasticSourceControlWorkspaceCreation::LaunchMakeWorkspaceOperation()
 	}
 	else
 	{
-		FNotification::DisplayFailure(MakeWorkspaceOperation->GetName());
+		FNotification::DisplayFailure(MakeWorkspaceOperation.Get());
 	}
 }
 
@@ -71,12 +71,12 @@ void FPlasticSourceControlWorkspaceCreation::LaunchMarkForAddOperation()
 		}
 		else
 		{
-			FNotification::DisplayFailure(MarkForAddOperation->GetName());
+			FNotification::DisplayFailure(MarkForAddOperation.Get());
 		}
 	}
 	else
 	{
-		FNotification::DisplayFailure(MarkForAddOperation->GetName());
+		FNotification::DisplayFailure(MarkForAddOperation.Get());
 	}
 }
 
@@ -102,7 +102,7 @@ void FPlasticSourceControlWorkspaceCreation::LaunchCheckInOperation()
 	}
 	else
 	{
-		FNotification::DisplayFailure(CheckInOperation->GetName());
+		FNotification::DisplayFailure(CheckInOperation.Get());
 	}
 }
 
@@ -118,14 +118,7 @@ void FPlasticSourceControlWorkspaceCreation::OnSourceControlOperationComplete(co
 	Notification.RemoveInProgress();
 
 	// Report result with a notification
-	if (InResult == ECommandResult::Succeeded)
-	{
-		FNotification::DisplaySuccess(InOperation->GetName());
-	}
-	else
-	{
-		FNotification::DisplayFailure(InOperation->GetName());
-	}
+	FNotification::DisplayResult(InOperation, InResult);
 }
 
 /** Path to the "ignore.conf" file */

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
@@ -576,7 +576,9 @@ TSharedPtr<SWidget> SPlasticSourceControlBranchesWidget::OnOpenContextMenu()
 	);
 
 	static const FText SwitchToBranchTooltip(LOCTEXT("SwitchToBranchTooltip", "Switch the current workspace to this branch."));
-	const FText& SwitchToBranchTooltipDynamic = bSingleNotCurrent ? SwitchToBranchTooltip : bSingleSelection ? SelectADifferentBranchTooltip : SelectASingleBranchTooltip;
+	const FText& SwitchToBranchTooltipDynamic =
+		bSingleNotCurrent ? SwitchToBranchTooltip :
+		bSingleSelection ? SelectADifferentBranchTooltip : SelectASingleBranchTooltip;
 	Section.AddMenuEntry(
 		TEXT("SwitchToBranch"),
 		LOCTEXT("SwitchToBranch", "Switch workspace to this branch"),
@@ -591,7 +593,10 @@ TSharedPtr<SWidget> SPlasticSourceControlBranchesWidget::OnOpenContextMenu()
 	Section.AddSeparator("PlasticSeparator1");
 
 	static const FText MergeBranchTooltip(LOCTEXT("MergeBranchTooltip", "Merge this branch into the current workspace."));
-	const FText& MergeBranchTooltipDynamic = bMergeXml ? bSingleNotCurrent ? MergeBranchTooltip : bSingleSelection ? SelectADifferentBranchTooltip : SelectASingleBranchTooltip : UpdateUVCSTooltip;
+	const FText& MergeBranchTooltipDynamic =
+		!bMergeXml ? UpdateUVCSTooltip :
+		bSingleNotCurrent ? MergeBranchTooltip :
+		bSingleSelection ? SelectADifferentBranchTooltip : SelectASingleBranchTooltip;
 	Section.AddMenuEntry(
 		TEXT("MergeBranch"),
 		LOCTEXT("MergeBranch", "Merge from this branch..."),

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
@@ -6,6 +6,7 @@
 #include "PlasticSourceControlOperations.h"
 #include "PlasticSourceControlProjectSettings.h"
 #include "PlasticSourceControlBranch.h"
+#include "PlasticSourceControlVersions.h"
 #include "SPlasticSourceControlBranchRow.h"
 #include "SPlasticSourceControlCreateBranch.h"
 #include "SPlasticSourceControlDeleteBranches.h"
@@ -538,6 +539,8 @@ TSharedPtr<SWidget> SPlasticSourceControlBranchesWidget::OnOpenContextMenu()
 		return nullptr;
 	}
 
+	const bool bMergeXml = FPlasticSourceControlModule::Get().GetProvider().GetPlasticScmVersion() >= PlasticSourceControlVersions::MergeXml;
+
 	UToolMenus* ToolMenus = UToolMenus::Get();
 	static const FName MenuName = "PlasticSourceControl.BranchesContextMenu";
 	if (!ToolMenus->IsMenuRegistered(MenuName))
@@ -584,7 +587,7 @@ TSharedPtr<SWidget> SPlasticSourceControlBranchesWidget::OnOpenContextMenu()
 		FSlateIcon(),
 		FUIAction(
 			FExecuteAction::CreateSP(this, &SPlasticSourceControlBranchesWidget::OnMergeBranchClicked, SelectedBranch),
-			FCanExecuteAction::CreateLambda([this, SelectedBranch]() { return (!SelectedBranch.IsEmpty()) && (SelectedBranch != CurrentBranchName); })
+			FCanExecuteAction::CreateLambda([this, bMergeXml, SelectedBranch]() { return bMergeXml && (!SelectedBranch.IsEmpty()) && (SelectedBranch != CurrentBranchName); })
 		)
 	);
 

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
@@ -1013,7 +1013,7 @@ FReply SPlasticSourceControlBranchesWidget::OnKeyDown(const FGeometry& MyGeometr
 			const FString& SelectedBranch = SelectedBranches[0];
 			// Note: this action require a confirmation dialog (while the Delete below already have one in OnDeleteBranchesClicked()).
 			const FText Message = FText::Format(LOCTEXT("SwitchToBranchDialog", "Switch workspace to branch {0}?"), FText::FromString(SelectedBranch));
-			const EAppReturnType::Type Choice = FMessageDialog::Open(EAppMsgType::YesNo, Message);
+			const EAppReturnType::Type Choice = FMessageDialog::Open(EAppMsgCategory::Info, EAppMsgType::YesNo, Message);
 			if (Choice == EAppReturnType::Yes)
 			{
 				OnSwitchToBranchClicked(SelectedBranch);

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
@@ -680,7 +680,7 @@ void SPlasticSourceControlBranchesWidget::CreateBranch(const FString& InParentBr
 			else
 			{
 				// Report failure with a notification (but nothing need to be reloaded since no local change is expected)
-				FNotification::DisplayFailure(CreateBranchOperation->GetName());
+				FNotification::DisplayFailure(CreateBranchOperation.Get());
 			}
 		}
 		else
@@ -722,7 +722,7 @@ void SPlasticSourceControlBranchesWidget::OnSwitchToBranchClicked(FString InBran
 			else
 			{
 				// Report failure with a notification (but nothing need to be reloaded since no local change is expected)
-				FNotification::DisplayFailure(SwitchToBranchOperation->GetName());
+				FNotification::DisplayFailure(SwitchToBranchOperation.Get());
 			}
 		}
 		else
@@ -768,7 +768,7 @@ void SPlasticSourceControlBranchesWidget::OnMergeBranchClicked(FString InBranchN
 				else
 				{
 					// Report failure with a notification (but nothing need to be reloaded since no local change is expected)
-					FNotification::DisplayFailure(MergeBranchOperation->GetName());
+					FNotification::DisplayFailure(MergeBranchOperation.Get());
 				}
 			}
 			else
@@ -820,7 +820,7 @@ void SPlasticSourceControlBranchesWidget::RenameBranch(const FString& InOldBranc
 		else
 		{
 			// Report failure with a notification (but nothing need to be reloaded since no local change is expected)
-			FNotification::DisplayFailure(RenameBranchOperation->GetName());
+			FNotification::DisplayFailure(RenameBranchOperation.Get());
 		}
 	}
 	else
@@ -863,7 +863,7 @@ void SPlasticSourceControlBranchesWidget::DeleteBranches(const TArray<FString>& 
 		else
 		{
 			// Report failure with a notification (but nothing need to be reloaded since no local change is expected)
-			FNotification::DisplayFailure(DeleteBranchesOperation->GetName());
+			FNotification::DisplayFailure(DeleteBranchesOperation.Get());
 		}
 	}
 	else
@@ -961,10 +961,10 @@ void SPlasticSourceControlBranchesWidget::OnCreateBranchOperationComplete(const 
 
 	Notification.RemoveInProgress();
 
+	FNotification::DisplayResult(InOperation, InResult);
+
 	if (InResult == ECommandResult::Succeeded)
 	{
-		FNotification::DisplaySuccess(InOperation->GetName());
-
 		if (bInSwitchWorkspace)
 		{
 			TSharedRef<FPlasticCreateBranch, ESPMode::ThreadSafe> CreateBranchOperation = StaticCastSharedRef<FPlasticCreateBranch>(InOperation);
@@ -978,8 +978,6 @@ void SPlasticSourceControlBranchesWidget::OnCreateBranchOperationComplete(const 
 	}
 	else
 	{
-		FNotification::DisplayFailure(InOperation->GetName());
-
 		EndRefreshStatus();
 	}
 }
@@ -997,15 +995,7 @@ void SPlasticSourceControlBranchesWidget::OnSwitchToBranchOperationComplete(cons
 
 	Notification.RemoveInProgress();
 
-	// Report result with a notification
-	if (InResult == ECommandResult::Succeeded)
-	{
-		FNotification::DisplaySuccess(InOperation->GetName());
-	}
-	else
-	{
-		FNotification::DisplayFailure(InOperation->GetName());
-	}
+	FNotification::DisplayResult(InOperation, InResult);
 }
 
 void SPlasticSourceControlBranchesWidget::OnMergeBranchOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult)
@@ -1018,15 +1008,7 @@ void SPlasticSourceControlBranchesWidget::OnMergeBranchOperationComplete(const F
 
 	Notification.RemoveInProgress();
 
-	// Report result with a notification
-	if (InResult == ECommandResult::Succeeded)
-	{
-		FNotification::DisplaySuccess(InOperation->GetName());
-	}
-	else
-	{
-		FNotification::DisplayFailure(InOperation->GetName());
-	}
+	FNotification::DisplayResult(InOperation, InResult);
 
 	EndRefreshStatus();
 }
@@ -1038,15 +1020,7 @@ void SPlasticSourceControlBranchesWidget::OnRenameBranchOperationComplete(const 
 
 	Notification.RemoveInProgress();
 
-	// Report result with a notification
-	if (InResult == ECommandResult::Succeeded)
-	{
-		FNotification::DisplaySuccess(InOperation->GetName());
-	}
-	else
-	{
-		FNotification::DisplayFailure(InOperation->GetName());
-	}
+	FNotification::DisplayResult(InOperation, InResult);
 }
 
 void SPlasticSourceControlBranchesWidget::OnDeleteBranchesOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult)
@@ -1056,15 +1030,7 @@ void SPlasticSourceControlBranchesWidget::OnDeleteBranchesOperationComplete(cons
 
 	Notification.RemoveInProgress();
 
-	// Report result with a notification
-	if (InResult == ECommandResult::Succeeded)
-	{
-		FNotification::DisplaySuccess(InOperation->GetName());
-	}
-	else
-	{
-		FNotification::DisplayFailure(InOperation->GetName());
-	}
+	FNotification::DisplayResult(InOperation, InResult);
 }
 
 void SPlasticSourceControlBranchesWidget::OnSourceControlProviderChanged(ISourceControlProvider& OldProvider, ISourceControlProvider& NewProvider)

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.cpp
@@ -692,7 +692,7 @@ void SPlasticSourceControlBranchesWidget::OnSwitchToBranchClicked(FString InBran
 			// Find and Unlink all loaded packages in Content directory to allow to update them
 			PackageUtils::UnlinkPackages(PackageUtils::ListAllPackages());
 
-			// Launch a custom "SwitchToBranch" operation
+			// Launch a custom "Switch" operation
 			FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
 			TSharedRef<FPlasticSwitchToBranch, ESPMode::ThreadSafe> SwitchToBranchOperation = ISourceControlOperation::Create<FPlasticSwitchToBranch>();
 			SwitchToBranchOperation->BranchName = InBranchName;

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlBranchesWidget.h
@@ -63,6 +63,7 @@ private:
 
 	void OnCreateBranchClicked(FString InParentBranchName);
 	void OnSwitchToBranchClicked(FString InBranchName);
+	void OnMergeBranchClicked(FString InBranchName);
 	void OnRenameBranchClicked(FString InBranchName);
 	void OnDeleteBranchesClicked(TArray<FString> InBranchNames);
 
@@ -76,6 +77,7 @@ private:
 	void OnGetBranchesOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
 	void OnCreateBranchOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult, const bool bInSwitchWorkspace);
 	void OnSwitchToBranchOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
+	void OnMergeBranchOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
 	void OnRenameBranchOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
 	void OnDeleteBranchesOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
 	void OnSourceControlProviderChanged(ISourceControlProvider& OldProvider, ISourceControlProvider& NewProvider);

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlCreateBranch.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlCreateBranch.cpp
@@ -59,9 +59,17 @@ void SPlasticSourceControlCreateBranch::Construct(const FArguments& InArgs)
 			[
 				SAssignNew(BranchNameTextBox, SEditableTextBox)
 				.HintText(LOCTEXT("PlasticCreateBrancheNameHint", "Name of the new branch"))
-				.OnTextChanged_Lambda([this](const FText& InExpressionText)
+				.OnTextChanged_Lambda([this](const FText& InText)
 				{
-					NewBranchName = InExpressionText.ToString();
+					NewBranchName = InText.ToString();
+				})
+				.OnTextCommitted_Lambda([this](const FText& InText, ETextCommit::Type TextCommitType)
+				{
+					NewBranchName = InText.ToString();
+					if (TextCommitType == ETextCommit::OnEnter)
+					{
+						CreateClicked();
+					}
 				})
 			]
 		]
@@ -88,9 +96,9 @@ void SPlasticSourceControlCreateBranch::Construct(const FArguments& InArgs)
 					SNew(SMultiLineEditableTextBox)
 					.AutoWrapText(true)
 					.HintText(LOCTEXT("PlasticCreateBrancheCommentHing", "Comments for the new branch"))
-					.OnTextCommitted_Lambda([this](const FText& InExpressionText, ETextCommit::Type)
+					.OnTextCommitted_Lambda([this](const FText& InText, ETextCommit::Type TextCommitType)
 					{
-						NewBranchComment = InExpressionText.ToString();
+						NewBranchComment = InText.ToString();
 					})
 				]
 			]

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlRenameBranch.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlRenameBranch.cpp
@@ -66,9 +66,17 @@ void SPlasticSourceControlRenameBranch::Construct(const FArguments& InArgs)
 			[
 				SAssignNew(BranchNameTextBox, SEditableTextBox)
 				.Text(FText::FromString(NewBranchName))
-				.OnTextChanged_Lambda([this](const FText& InExpressionText)
+				.OnTextChanged_Lambda([this](const FText& InText)
 				{
-					NewBranchName = InExpressionText.ToString();
+					NewBranchName = InText.ToString();
+				})
+				.OnTextCommitted_Lambda([this](const FText& InText, ETextCommit::Type TextCommitType)
+				{
+					NewBranchName = InText.ToString();
+					if (TextCommitType == ETextCommit::OnEnter)
+					{
+						RenamedClicked();
+					}
 				})
 			]
 		]


### PR DESCRIPTION
- New RunMergeBranch() Utils function calling cm merge --xml
- New ParseMergeResults() XML Parser
- New "MergeBranch" Operation and Worker calling the corresponding new Utils
- Add a menu entry, a MergeBranch() method calling the operation, and a callback on completion. Uses a simple Dialog to ask the user for confirmation
    - Uses a simple Dialog to ask the user for confirmation
- Add a version check since merge --xml is only supported since 11.0.16.7726 from January 2023
- Add an OnKeyDown() to interpret F5, Enter and Delete keys
- Also put all files from the merge into the Default changelist

Also
- Fix SwitchToBranch operation to call RunUpdateStatus() on UpdatedFiles. Without that the Content Browser was displaying some unknown state icon on some assets.
- Notification overall to display command line error messages
- Branch context menu now with dynamic Tooltip to explain what prevents each entry to be active.