### PR TITLE
Fix warning unknown file status AD+LD

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.cpp
@@ -131,11 +131,11 @@ static EWorkspaceState StateFromStatus(const FString& InFileStatus, const bool b
 {
 	EWorkspaceState State;
 
-	if (InFileStatus == "CH") // Modified but not Checked-Out
+	if (InFileStatus == TEXT("CH")) // Modified but not Checked-Out
 	{
 		State = EWorkspaceState::Changed;
 	}
-	else if (InFileStatus == "CO") // Checked-Out with no change, or "don't know" if using on an old version of cm
+	else if (InFileStatus == TEXT("CO")) // Checked-Out with no change, or "don't know" if using on an old version of cm
 	{
 		// Recent version can distinguish between CheckedOut with or with no changes
 		if (bInUsesCheckedOutChanged)
@@ -147,7 +147,7 @@ static EWorkspaceState StateFromStatus(const FString& InFileStatus, const bool b
 			State = EWorkspaceState::CheckedOutChanged; // Older version; need to assume it is changed to retain behavior
 		}
 	}
-	else if (InFileStatus == "CO+CH") // Checked-Out and changed from the new --iscochanged
+	else if (InFileStatus == TEXT("CO+CH")) // Checked-Out and changed from the new --iscochanged
 	{
 		State = EWorkspaceState::CheckedOutChanged; // Recent version; here it's checkedout with changes
 	}
@@ -163,23 +163,23 @@ static EWorkspaceState StateFromStatus(const FString& InFileStatus, const bool b
 	{
 		State = EWorkspaceState::Replaced;
 	}
-	else if (InFileStatus == "AD")
+	else if (InFileStatus == TEXT("AD"))
 	{
 		State = EWorkspaceState::Added;
 	}
-	else if ((InFileStatus == "PR") || (InFileStatus == "LM")) // Not Controlled/Not in Depot/Untracked (or Locally Moved/Renamed)
+	else if ((InFileStatus == TEXT("PR")) || (InFileStatus == TEXT("LM"))) // Not Controlled/Not in Depot/Untracked (or Locally Moved/Renamed)
 	{
 		State = EWorkspaceState::Private;
 	}
-	else if (InFileStatus == "IG")
+	else if (InFileStatus == TEXT("IG"))
 	{
 		State = EWorkspaceState::Ignored;
 	}
-	else if (InFileStatus == "DE")
+	else if (InFileStatus == TEXT("DE"))
 	{
 		State = EWorkspaceState::Deleted; // Deleted (removed from source control)
 	}
-	else if (InFileStatus == "LD")
+	else if (InFileStatus == TEXT("LD"))
 	{
 		State = EWorkspaceState::LocallyDeleted; // Locally Deleted (ie. missing)
 	}

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.cpp
@@ -179,7 +179,7 @@ static EWorkspaceState StateFromStatus(const FString& InFileStatus, const bool b
 	{
 		State = EWorkspaceState::Deleted; // Deleted (removed from source control)
 	}
-	else if (InFileStatus == TEXT("LD"))
+	else if (InFileStatus.Contains(TEXT("LD"))) // "LD", "AD+LD"
 	{
 		State = EWorkspaceState::LocallyDeleted; // Locally Deleted (ie. missing)
 	}


### PR DESCRIPTION
Fix parsing issue when a folder is added and then moved, since Unreal doesn't explicitly manage folder in source control (because Perforce doesn't)

**Steps to reproduce**

1. Within Unreal Editor, add a new folder and a new blueprint to it
2. move the folder to another part of the tree (or rename it)
3. Use Revision Control -> Submit Content

The initial folder is both added to source control and seen as locally deleted

    LogSourceControl: Warning: Unknown file status 'AD+LD'