### PR TITLE
Fix getting the username in the case of using multiple accounts

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.h
@@ -62,6 +62,8 @@ struct FRemoveRedundantErrors
 	FString Filter;
 };
 
+bool ParseProfileInfo(TArray<FString>& InResults, const FString& InServerUrl, FString& OutUserName);
+
 bool ParseWorkspaceInfo(TArray<FString>& InResults, FString& OutBranchName, FString& OutRepositoryName, FString& OutServerUrl);
 
 bool GetChangesetFromWorkspaceStatus(const TArray<FString>& InResults, int32& OutChangeset);

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
@@ -136,20 +136,25 @@ void FPlasticSourceControlProvider::CheckPlasticAvailability()
 
 		bUsesLocalReadOnlyState = PlasticSourceControlUtils::GetConfigSetFilesAsReadOnly();
 
-		// Get user name (from the global Unity Version Control client config)
-		PlasticSourceControlUtils::GetUserName(UserName);
-
 		// Register Console Commands
 		PlasticSourceControlConsole.Register();
 
-		if (!bWorkspaceFound)
+		if (bWorkspaceFound)
+		{
+			TArray<FString> ErrorMessages;
+			PlasticSourceControlUtils::GetWorkspaceInfo(BranchName, RepositoryName, ServerUrl, ErrorMessages);
+			UserName = PlasticSourceControlUtils::GetProfileUserName(ServerUrl);
+		}
+		else
 		{
 			// This info message is only useful here, if bPlasticAvailable, for the Login window
 			FFormatNamedArguments Args;
 			Args.Add(TEXT("WorkspacePath"), FText::FromString(PathToWorkspaceRoot));
 			FMessageLog("SourceControl").Info(FText::Format(LOCTEXT("NotInAWorkspace", "{WorkspacePath} is not in a workspace."), Args));
 
+			// Get default server and user name (from the global client config)
 			ServerUrl = PlasticSourceControlUtils::GetConfigDefaultRepServer();
+			UserName = PlasticSourceControlUtils::GetDefaultUserName();
 		}
 	}
 }

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -139,15 +139,35 @@ FString GetConfigDefaultRepServer()
 	return ServerUrl;
 }
 
-void GetUserName(FString& OutUserName)
+FString GetDefaultUserName()
 {
+	FString UserName;
 	TArray<FString> Results;
 	TArray<FString> ErrorMessages;
 	const bool bResult = RunCommand(TEXT("whoami"), TArray<FString>(), TArray<FString>(), Results, ErrorMessages);
 	if (bResult && Results.Num() > 0)
 	{
-		OutUserName = MoveTemp(Results[0]);
+		UserName = MoveTemp(Results[0]);
 	}
+
+	return UserName;
+}
+
+FString GetProfileUserName(const FString& InServerUrl)
+{
+	FString UserName;
+	TArray<FString> Results;
+	TArray<FString> Parameters;
+	TArray<FString> ErrorMessages;
+	Parameters.Add("list");
+	Parameters.Add(TEXT("--format=\"{server};{user}\""));
+	bool bResult = RunCommand(TEXT("profile"), Parameters, TArray<FString>(), Results, ErrorMessages);
+	if (bResult)
+	{
+		bResult = PlasticSourceControlParsers::ParseProfileInfo(Results, InServerUrl, UserName);
+	}
+
+	return UserName;
 }
 
 bool GetWorkspaceName(const FString& InWorkspaceRoot, FString& OutWorkspaceName, TArray<FString>& OutErrorMessages)

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
@@ -88,10 +88,17 @@ bool GetConfigSetFilesAsReadOnly();
 FString GetConfigDefaultRepServer();
 
 /**
- * Get Unity Version Control current user
- * @param	OutUserName			Name of the Unity Version Control user configured globally
+ * Get Unity Version Control user for the default server
+ * @returns	Name of the Unity Version Control user configured globally
  */
-void GetUserName(FString& OutUserName);
+FString GetDefaultUserName();
+
+/**
+ * Get Unity Version Control user for the specified server
+ * @param	InServerUrl		Name of the specified server
+ * @returns	Name of the Unity Version Control user for the specified server
+ */
+FString GetProfileUserName(const FString& InServerUrl);
 
 /**
  * Get workspace name


### PR DESCRIPTION
Use the "cm profile list" command instead of "cm whoami" that only returns the user of the default server for now