### PR TITLE
The View Pending Changes window should show all local modifications as well

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -851,7 +851,13 @@ bool FPlasticRevertUnchangedWorker::Execute(FPlasticSourceControlCommand& InComm
 	Parameters.Add(TEXT("-R"));
 
 	// Filter out files that we shouldn't try to uncheckout!
-	TArray<FString> Files = GetFilesCheckedOut(GetProvider(), GetFilesFromCommand(GetProvider(), InCommand));
+	TArray<FString> FilesFromCommand = GetFilesFromCommand(GetProvider(), InCommand);
+	TArray<FString> Files = GetFilesCheckedOut(GetProvider(), FilesFromCommand);
+	if (Files.Num() == 0 && FilesFromCommand.Num() > 0)
+	{
+		// If the command specified a set of files but none are checked out, do nothing
+		return true;
+	}
 
 	// revert the checkout of all unchanged files recursively
 	InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("uncounchanged"), Parameters, Files, InCommand.InfoMessages, InCommand.ErrorMessages);

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -837,7 +837,8 @@ bool FPlasticRevertUnchangedWorker::Execute(FPlasticSourceControlCommand& InComm
 	TArray<FString> Parameters;
 	Parameters.Add(TEXT("-R"));
 
-	TArray<FString> Files = GetFilesFromCommand(GetProvider(), InCommand);
+	// Filter out files that we shouldn't try to uncheckout!
+	TArray<FString> Files = GetFilesCheckedOut(GetProvider(), GetFilesFromCommand(GetProvider(), InCommand));
 
 	// revert the checkout of all unchanged files recursively
 	InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("uncounchanged"), Parameters, Files, InCommand.InfoMessages, InCommand.ErrorMessages);

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -324,7 +324,7 @@ static void UpdateChangelistState(FPlasticSourceControlProvider& SCCProvider, co
 
 			// Add a shared reference to the state of the file, that will then be updated by PlasticSourceControlUtils::UpdateCachedStates()
 			TSharedRef<FPlasticSourceControlState, ESPMode::ThreadSafe> State = SCCProvider.GetStateInternal(InState.GetFilename());
-			ChangelistState->Files.Add(State);
+			ChangelistState->Files.AddUnique(State);
 
 			// Keep the changelist stored with cached file state in sync with the actual changelist that owns this file.
 			State->Changelist = InChangelist;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -317,8 +317,7 @@ static void UpdateChangelistState(FPlasticSourceControlProvider& SCCProvider, co
 
 		for (const FPlasticSourceControlState& InState : InStates)
 		{
-			// Note: cannot use IsModified() because cm cannot yet handle local modifications in changelists, only the GUI can
-			if (!InState.IsCheckedOutImplementation())
+			if (!InState.IsPendingChanges())
 			{
 				continue;
 			}
@@ -843,7 +842,7 @@ bool FPlasticRevertUnchangedWorker::UpdateStates()
 	// Update affected changelists if any
 	for (const FPlasticSourceControlState& NewState : States)
 	{
-		if (!NewState.IsCheckedOutImplementation())
+		if (!NewState.IsPendingChanges())
 		{
 			TSharedRef<FPlasticSourceControlState, ESPMode::ThreadSafe> State = GetProvider().GetStateInternal(NewState.GetFilename());
 			if (State->Changelist.IsInitialized())
@@ -943,7 +942,8 @@ bool FPlasticRevertAllWorker::UpdateStates()
 	for (const FPlasticSourceControlState& NewState : States)
 	{
 		// TODO: also detect files that were added and are now private! Should be removed as well from their changelist
-		if (!NewState.IsCheckedOutImplementation())
+		// TODO: revisit that, as it's perhaps more subtle now, depending of if it's the Default changelist or not!
+		if (!NewState.IsPendingChanges())
 		{
 			TSharedRef<FPlasticSourceControlState, ESPMode::ThreadSafe> State = GetProvider().GetStateInternal(NewState.GetFilename());
 			if (State->Changelist.IsInitialized())
@@ -1393,7 +1393,8 @@ bool FPlasticUpdateStatusWorker::UpdateStates()
 	// Update affected changelists if any (in case of a file reverted outside of the Unreal Editor)
 	for (const FPlasticSourceControlState& NewState : States)
 	{
-		if (!NewState.IsCheckedOutImplementation())
+		// TODO: revisit that, as it's perhaps more subtle now, depending of if it's the Default changelist or not!
+		if (!NewState.IsPendingChanges())
 		{
 			TSharedRef<FPlasticSourceControlState, ESPMode::ThreadSafe> State = GetProvider().GetStateInternal(NewState.GetFilename());
 			if (State->Changelist.IsInitialized())

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -396,7 +396,7 @@ bool DeleteChangelist(const FPlasticSourceControlProvider& PlasticSourceControlP
 	}
 }
 
-TArray<FString> FileNamesFromFileStates(const TArray<FSourceControlStateRef>& InFileStates)
+static TArray<FString> FileNamesFromFileStates(const TArray<FSourceControlStateRef>& InFileStates)
 {
 	TArray<FString> Files;
 
@@ -410,7 +410,7 @@ TArray<FString> FileNamesFromFileStates(const TArray<FSourceControlStateRef>& In
 
 #endif
 
-TArray<FString> GetFilesFromCommand(FPlasticSourceControlProvider& PlasticSourceControlProvider, FPlasticSourceControlCommand& InCommand)
+static TArray<FString> GetFilesFromCommand(FPlasticSourceControlProvider& PlasticSourceControlProvider, FPlasticSourceControlCommand& InCommand)
 {
 	TArray<FString> Files;
 #if ENGINE_MAJOR_VERSION == 5
@@ -1736,7 +1736,7 @@ bool FPlasticGetPendingChangelistsWorker::UpdateStates()
 	return bUpdated;
 }
 
-FPlasticSourceControlChangelist GenerateUniqueChangelistName(FPlasticSourceControlProvider& PlasticSourceControlProvider)
+static FPlasticSourceControlChangelist GenerateUniqueChangelistName(FPlasticSourceControlProvider& PlasticSourceControlProvider)
 {
 	FPlasticSourceControlChangelist NewChangelist;
 
@@ -1755,7 +1755,7 @@ FPlasticSourceControlChangelist GenerateUniqueChangelistName(FPlasticSourceContr
 	return NewChangelist;
 }
 
-FPlasticSourceControlChangelist CreatePendingChangelist(FPlasticSourceControlProvider& PlasticSourceControlProvider, const FString& InDescription, TArray<FString>& InInfoMessages, TArray<FString>& InErrorMessages)
+static FPlasticSourceControlChangelist CreatePendingChangelist(FPlasticSourceControlProvider& PlasticSourceControlProvider, const FString& InDescription, TArray<FString>& InInfoMessages, TArray<FString>& InErrorMessages)
 {
 	FPlasticSourceControlChangelist NewChangelist = GenerateUniqueChangelistName(PlasticSourceControlProvider);
 
@@ -1788,7 +1788,7 @@ FPlasticSourceControlChangelist CreatePendingChangelist(FPlasticSourceControlPro
 	return NewChangelist;
 }
 
-bool EditChangelistDescription(const FPlasticSourceControlProvider& PlasticSourceControlProvider, const FPlasticSourceControlChangelist& InChangelist, const FString& InDescription, TArray<FString>& InInfoMessages, TArray<FString>& InErrorMessages)
+static bool EditChangelistDescription(const FPlasticSourceControlProvider& PlasticSourceControlProvider, const FPlasticSourceControlChangelist& InChangelist, const FString& InDescription, TArray<FString>& InInfoMessages, TArray<FString>& InErrorMessages)
 {
 	TArray<FString> Parameters;
 	Parameters.Add(TEXT("edit"));
@@ -1811,7 +1811,7 @@ bool EditChangelistDescription(const FPlasticSourceControlProvider& PlasticSourc
 	}
 }
 
-bool MoveFilesToChangelist(const FPlasticSourceControlProvider& PlasticSourceControlProvider, const FPlasticSourceControlChangelist& InChangelist, const TArray<FString>& InFiles, TArray<FString>& OutResults, TArray<FString>& OutErrorMessages)
+static bool MoveFilesToChangelist(const FPlasticSourceControlProvider& PlasticSourceControlProvider, const FPlasticSourceControlChangelist& InChangelist, const TArray<FString>& InFiles, TArray<FString>& OutResults, TArray<FString>& OutErrorMessages)
 {
 	if (InFiles.Num() > 0)
 	{
@@ -2119,7 +2119,7 @@ bool FPlasticReopenWorker::UpdateStates()
 	}
 }
 
-bool CreateShelve(const FString& InChangelistName, const FString& InChangelistDescription, const TArray<FString>& InFilesToShelve, int32& OutShelveId, TArray<FString>& OutErrorMessages)
+static bool CreateShelve(const FString& InChangelistName, const FString& InChangelistDescription, const TArray<FString>& InFilesToShelve, int32& OutShelveId, TArray<FString>& OutErrorMessages)
 {
 	TArray<FString> Results;
 	TArray<FString> Parameters;
@@ -2148,7 +2148,7 @@ bool CreateShelve(const FString& InChangelistName, const FString& InChangelistDe
 	return OutShelveId != ISourceControlState::INVALID_REVISION;
 }
 
-bool DeleteShelve(const int32 InShelveId, TArray<FString>& OutErrorMessages)
+static bool DeleteShelve(const int32 InShelveId, TArray<FString>& OutErrorMessages)
 {
 	TArray<FString> Results;
 	TArray<FString> Parameters;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlSettings.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlSettings.cpp
@@ -59,6 +59,18 @@ void FPlasticSourceControlSettings::SetUpdateStatusOtherBranches(const bool bInU
 	bUpdateStatusOtherBranches = bInUpdateStatusOtherBranches;
 }
 
+bool FPlasticSourceControlSettings::GetViewLocalChanges() const
+{
+	FScopeLock ScopeLock(&CriticalSection);
+	return bViewLocalChanges;
+}
+
+void FPlasticSourceControlSettings::SetViewLocalChanges(const bool bInViewLocalChanges)
+{
+	FScopeLock ScopeLock(&CriticalSection);
+	bViewLocalChanges = bInViewLocalChanges;
+}
+
 bool FPlasticSourceControlSettings::GetEnableVerboseLogs() const
 {
 	FScopeLock ScopeLock(&CriticalSection);
@@ -79,6 +91,7 @@ void FPlasticSourceControlSettings::LoadSettings()
 	GConfig->GetString(*PlasticSettingsConstants::SettingsSection, TEXT("BinaryPath"), BinaryPath, IniFile);
 	GConfig->GetBool(*PlasticSettingsConstants::SettingsSection, TEXT("UpdateStatusAtStartup"), bUpdateStatusAtStartup, IniFile);
 	GConfig->GetBool(*PlasticSettingsConstants::SettingsSection, TEXT("UpdateStatusOtherBranches"), bUpdateStatusOtherBranches, IniFile);
+	GConfig->GetBool(*PlasticSettingsConstants::SettingsSection, TEXT("ViewLocalChanges"), bViewLocalChanges, IniFile);
 	GConfig->GetBool(*PlasticSettingsConstants::SettingsSection, TEXT("EnableVerboseLogs"), bEnableVerboseLogs, IniFile);
 }
 
@@ -89,5 +102,6 @@ void FPlasticSourceControlSettings::SaveSettings() const
 	GConfig->SetString(*PlasticSettingsConstants::SettingsSection, TEXT("BinaryPath"), *BinaryPath, IniFile);
 	GConfig->SetBool(*PlasticSettingsConstants::SettingsSection, TEXT("UpdateStatusAtStartup"), bUpdateStatusAtStartup, IniFile);
 	GConfig->SetBool(*PlasticSettingsConstants::SettingsSection, TEXT("UpdateStatusOtherBranches"), bUpdateStatusOtherBranches, IniFile);
+	GConfig->SetBool(*PlasticSettingsConstants::SettingsSection, TEXT("ViewLocalChanges"), bViewLocalChanges, IniFile);
 	GConfig->SetBool(*PlasticSettingsConstants::SettingsSection, TEXT("EnableVerboseLogs"), bEnableVerboseLogs, IniFile);
 }

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlSettings.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlSettings.h
@@ -19,6 +19,10 @@ public:
 	bool GetUpdateStatusOtherBranches() const;
 	void SetUpdateStatusOtherBranches(const bool bInUpdateStatusOtherBranches);
 
+	/** Enable the "View Changes" (changelists) window to also display locally Changed and Private files (can be slow). */
+	bool GetViewLocalChanges() const;
+	void SetViewLocalChanges(const bool bInViewLocalChanges);
+
 	/** Enable LogSourceControl Verbose logs */
 	bool GetEnableVerboseLogs() const;
 	void SetEnableVerboseLogs(const bool bInEnableVerboseLogs);
@@ -45,6 +49,9 @@ private:
 	/** Enable Update status to call "history" to detect recent changesets on other branches (can be slow). */
 	bool bUpdateStatusOtherBranches = false;
 
-	/** Override LogSourceControl verbosity level to Verbose, and back, if not already VeryVerbose */
+	/** Enable the "View Changes" (changelists) window to also display Private and locally Changed assets (even though they cannot be moved to other changelists). */
+	bool bViewLocalChanges = true;
+
+	/** Override LogSourceControl verbosity level to Verbose, and back, if not already VeryVerbose. */
 	bool bEnableVerboseLogs = false;
 };

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
@@ -612,6 +612,13 @@ bool FPlasticSourceControlState::IsCheckedOut() const
 	}
 }
 
+bool FPlasticSourceControlState::IsPendingChanges() const
+{
+	return WorkspaceState != EWorkspaceState::Unknown
+		&& WorkspaceState != EWorkspaceState::Ignored
+		&& WorkspaceState != EWorkspaceState::Controlled;
+}
+
 bool FPlasticSourceControlState::IsCheckedOutImplementation() const
 {
 	const bool bIsCheckedOut = WorkspaceState == EWorkspaceState::CheckedOutChanged

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.h
@@ -166,6 +166,7 @@ public:
 	virtual bool IsConflicted() const override;
 	virtual bool CanRevert() const override;
 
+	bool IsPendingChanges() const;
 	bool IsCheckedOutImplementation() const;
 	bool IsLocked() const;
 	bool IsRetainedInOtherBranch() const;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -940,14 +940,15 @@ bool RunGetChangelists(TArray<FPlasticSourceControlChangelistState>& OutChangeli
 	FString Errors;
 	TArray<FString> Parameters;
 	Parameters.Add(TEXT("--changelists"));
-	// NOTE: don't use "--all" to avoid searching for --localmoved since it's the most time consuming (beside --changed)
-	// and its not used by the plugin (matching similarities doesn't seem to work with .uasset files)
 	Parameters.Add(TEXT("--controlledchanged"));
-	// TODO: add a user settings to avoid searching for --changed and --localdeleted, to work like Perforce on big projects,
-	// provided that the user understands the consequences (they won't see assets modified locally without a proper checkout)
-	Parameters.Add(TEXT("--changed"));
-	Parameters.Add(TEXT("--localdeleted"));
-	Parameters.Add(TEXT("--private"));
+	if (FPlasticSourceControlModule::Get().GetProvider().AccessSettings().GetViewLocalChanges())
+	{
+		// NOTE: don't use "--all" to avoid searching for --localmoved since it's the most time consuming (beside --changed)
+		// and its not used by the plugin (matching similarities doesn't seem to work with .uasset files)
+		Parameters.Add(TEXT("--changed"));
+		Parameters.Add(TEXT("--localdeleted"));
+		Parameters.Add(TEXT("--private"));
+	}
 	Parameters.Add(TEXT("--noheader"));
 	Parameters.Add(TEXT("--xml"));
 	Parameters.Add(TEXT("--encoding=\"utf-8\""));

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -940,7 +940,14 @@ bool RunGetChangelists(TArray<FPlasticSourceControlChangelistState>& OutChangeli
 	FString Errors;
 	TArray<FString> Parameters;
 	Parameters.Add(TEXT("--changelists"));
+	// NOTE: don't use "--all" to avoid searching for --localmoved since it's the most time consuming (beside --changed)
+	// and its not used by the plugin (matching similarities doesn't seem to work with .uasset files)
 	Parameters.Add(TEXT("--controlledchanged"));
+	// TODO: add a user settings to avoid searching for --changed and --localdeleted, to work like Perforce on big projects,
+	// provided that the user understands the consequences (they won't see assets modified locally without a proper checkout)
+	Parameters.Add(TEXT("--changed"));
+	Parameters.Add(TEXT("--localdeleted"));
+	Parameters.Add(TEXT("--private"));
 	Parameters.Add(TEXT("--noheader"));
 	Parameters.Add(TEXT("--xml"));
 	Parameters.Add(TEXT("--encoding=\"utf-8\""));

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.cpp
@@ -347,6 +347,22 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 				.Font(Font)
 			]
 		]
+		// Option for the View Changes (Changelists) window to also show locally Changed and Private files
+		+SVerticalBox::Slot()
+		.AutoHeight()
+		.Padding(2.0f)
+		.VAlign(VAlign_Center)
+		[
+			SNew(SCheckBox)
+			.ToolTipText(LOCTEXT("ViewLocalChanges_Tooltip", "Enable the \"View Changes\" window to search for and show locally Changed and Private files (can be slow)."))
+			.IsChecked(SPlasticSourceControlSettings::IsViewLocalChangesChecked())
+			.OnCheckStateChanged(this, &SPlasticSourceControlSettings::OnCheckedViewLocalChanges)
+			[
+				SNew(STextBlock)
+				.Text(LOCTEXT("ViewLocalChanges", "Enable the \"View Changes\" window to list local Changes."))
+				.Font(Font)
+			]
+		]
 		// Option to enable Source Control Verbose logs
 		+SVerticalBox::Slot()
 		.AutoHeight()
@@ -605,6 +621,19 @@ ECheckBoxState SPlasticSourceControlSettings::IsUpdateStatusOtherBranchesChecked
 {
 	FPlasticSourceControlSettings& PlasticSettings = FPlasticSourceControlModule::Get().GetProvider().AccessSettings();
 	return PlasticSettings.GetUpdateStatusOtherBranches() ? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
+}
+
+void SPlasticSourceControlSettings::OnCheckedViewLocalChanges(ECheckBoxState NewCheckedState)
+{
+	FPlasticSourceControlSettings& PlasticSettings = FPlasticSourceControlModule::Get().GetProvider().AccessSettings();
+	PlasticSettings.SetViewLocalChanges(NewCheckedState == ECheckBoxState::Checked);
+	PlasticSettings.SaveSettings();
+}
+
+ECheckBoxState SPlasticSourceControlSettings::IsViewLocalChangesChecked() const
+{
+	FPlasticSourceControlSettings& PlasticSettings = FPlasticSourceControlModule::Get().GetProvider().AccessSettings();
+	return PlasticSettings.GetViewLocalChanges() ? ECheckBoxState::Checked : ECheckBoxState::Unchecked;
 }
 
 void SPlasticSourceControlSettings::OnCheckedEnableVerboseLogs(ECheckBoxState NewCheckedState)

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.cpp
@@ -359,7 +359,7 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 			.OnCheckStateChanged(this, &SPlasticSourceControlSettings::OnCheckedViewLocalChanges)
 			[
 				SNew(STextBlock)
-				.Text(LOCTEXT("ViewLocalChanges", "Enable the \"View Changes\" window to list local Changes."))
+				.Text(LOCTEXT("ViewLocalChanges", "Show local Changes in the \"View Changes\" window."))
 				.Font(Font)
 			]
 		]

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.h
@@ -56,6 +56,9 @@ private:
 	void OnCheckedUpdateStatusOtherBranches(ECheckBoxState NewCheckedState);
 	ECheckBoxState IsUpdateStatusOtherBranchesChecked() const;
 
+	void OnCheckedViewLocalChanges(ECheckBoxState NewCheckedState);
+	ECheckBoxState IsViewLocalChangesChecked() const;
+
 	void OnCheckedEnableVerboseLogs(ECheckBoxState NewCheckedState);
 	ECheckBoxState IsEnableVerboseLogsChecked() const;
 


### PR DESCRIPTION
The View Pending Changes window should be able to display all file states others than Unknown, Ignored or Controlled (Unchanged)

- RunGetChangelists() now collect local states instead of --controlledchanged only
- New Source Control Settings to disable this in case it's becoming to costly (on big projects)
- Implement a new FPlasticSourceControlState::IsPendingChanges()
- Operations on Changelists are now using IsPendingChanges() instead of IsCheckedOutImplementation()
