### PR TITLE
Add a Configure Rules button to the View Locks window #139

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlMenu.cpp
@@ -516,11 +516,7 @@ void FPlasticSourceControlMenu::VisitSupportURLClicked() const
 
 void FPlasticSourceControlMenu::VisitLockRulesURLClicked(const FString InOrganizationName) const
 {
-	const FString OrganizationLockRulesURL = FString::Printf(
-		TEXT("https://dashboard.unity3d.com/devops/organizations/default/plastic-scm/organizations/%s/lock-rules"),
-		*InOrganizationName
-	);
-	FPlatformProcess::LaunchURL(*OrganizationLockRulesURL, NULL, NULL);
+	PlasticSourceControlUtils::OpenLockRulesInCloudDashboard(InOrganizationName);
 }
 
 void FPlasticSourceControlMenu::OpenDeskoptApp() const

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -93,6 +93,15 @@ FString FindDesktopApplicationPath()
 	return DesktopAppPath;
 }
 
+void OpenLockRulesInCloudDashboard(const FString& InOrganizationName)
+{
+	const FString OrganizationLockRulesURL = FString::Printf(
+		TEXT("https://dashboard.unity3d.com/devops/organizations/default/plastic-scm/organizations/%s/lock-rules"),
+		*InOrganizationName
+	);
+	FPlatformProcess::LaunchURL(*OrganizationLockRulesURL, NULL, NULL);
+}
+
 // Find the root of the workspace, looking from the provided path and upward in its parent directories.
 bool GetWorkspacePath(const FString& InPath, FString& OutWorkspaceRoot)
 {

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
@@ -56,6 +56,13 @@ FString FindPlasticBinaryPath();
 FString FindDesktopApplicationPath();
 
 /**
+ * Open the Unity Cloud Dashboard on the page to show and manage Lock Rules.
+ *
+ * @param	InOrganizationName	Name of the organization to use, from the server URL
+ */
+void OpenLockRulesInCloudDashboard(const FString& InOrganizationName);
+
+/**
  * Find the root of the Plastic workspace, looking from the GameDir and upward in its parent directories
  * @param InPathToGameDir		The path to the Game Directory
  * @param OutWorkspaceRoot		The path to the root directory of the Plastic workspace if found, else the path to the GameDir

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlLocksWidget.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlLocksWidget.cpp
@@ -44,6 +44,8 @@ void SPlasticSourceControlLocksWidget::Construct(const FArguments& InArgs)
 
 	CurrentBranchName = FPlasticSourceControlModule::Get().GetProvider().GetBranchName();
 
+	const FString OrganizationName = FPlasticSourceControlModule::Get().GetProvider().GetCloudOrganization();
+
 	SearchTextFilter = MakeShared<TTextFilter<const FPlasticSourceControlLock&>>(TTextFilter<const FPlasticSourceControlLock&>::FItemToStringArray::CreateSP(this, &SPlasticSourceControlLocksWidget::PopulateItemSearchStrings));
 	SearchTextFilter->OnChanged().AddSP(this, &SPlasticSourceControlLocksWidget::OnRefreshUI);
 
@@ -63,25 +65,77 @@ void SPlasticSourceControlLocksWidget::Construct(const FArguments& InArgs)
 			[
 				SNew(SHorizontalBox)
 				+SHorizontalBox::Slot()
-				.HAlign(HAlign_Left)
+				.FillWidth(1.0f)
+				[
+					SNew(SHorizontalBox)
+					+SHorizontalBox::Slot()
+					.HAlign(HAlign_Left)
+					.VAlign(VAlign_Center)
+					.AutoWidth()
+					[
+						CreateToolBar()
+					]
+					+SHorizontalBox::Slot()
+					.MaxWidth(10.0f)
+					[
+						SNew(SSpacer)
+					]
+					+SHorizontalBox::Slot()
+					.VAlign(VAlign_Center)
+					.MaxWidth(300.0f)
+					[
+						SAssignNew(FileSearchBox, SSearchBox)
+						.HintText(LOCTEXT("SearchLocks", "Search Locks"))
+						.ToolTipText(LOCTEXT("PlasticLocksSearch_Tooltip", "Filter the list of locks by keyword."))
+						.OnTextChanged(this, &SPlasticSourceControlLocksWidget::OnSearchTextChanged)
+					]
+				]
+				+SHorizontalBox::Slot()
+				.HAlign(HAlign_Right)
 				.VAlign(VAlign_Center)
 				.AutoWidth()
 				[
-					CreateToolBar()
-				]
-				+SHorizontalBox::Slot()
-				.MaxWidth(10.0f)
-				[
-					SNew(SSpacer)
-				]
-				+SHorizontalBox::Slot()
-				.VAlign(VAlign_Center)
-				.MaxWidth(300.0f)
-				[
-					SAssignNew(FileSearchBox, SSearchBox)
-					.HintText(LOCTEXT("SearchLocks", "Search Locks"))
-					.ToolTipText(LOCTEXT("PlasticLocksSearch_Tooltip", "Filter the list of locks by keyword."))
-					.OnTextChanged(this, &SPlasticSourceControlLocksWidget::OnSearchTextChanged)
+					// Button to Configure Lock Rules in the cloud (only enabled for a cloud repository)
+					SNew(SButton)
+					.ContentPadding(FMargin(6.0f, 0.0f))
+					.IsEnabled(!OrganizationName.IsEmpty())
+					.ToolTipText(OrganizationName.IsEmpty() ?
+						LOCTEXT("PlasticLockRulesURLTooltipDisabled", "Web link to the Unity Dashboard disabled. Only available for Cloud repositories.") :
+						LOCTEXT("PlasticLockRulesURLTooltipEnabled", "Navigate to lock rules configuration page in the Unity Dashboard."))
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
+					.ButtonStyle(FAppStyle::Get(), "SimpleButton")
+#else
+					.ButtonStyle(FEditorStyle::Get(), "SimpleButton")
+#endif
+					.OnClicked(this, &SPlasticSourceControlLocksWidget::OnConfigureLockRulesClicked, OrganizationName)
+					[
+						SNew(SHorizontalBox)
+						+SHorizontalBox::Slot()
+						.AutoWidth()
+						.VAlign(VAlign_Center)
+						.HAlign(HAlign_Center)
+						[
+							SNew(SImage)
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
+							.Image(FAppStyle::GetBrush("PropertyWindow.Locked"))
+#else
+							.Image(FEditorStyle::GetBrush("PropertyWindow.Locked"))
+#endif
+						]
+						+SHorizontalBox::Slot()
+						.AutoWidth()
+						.VAlign(VAlign_Center)
+						.Padding(5.0f, 0.0f, 0.0f, 0.0f)
+						[
+							SNew(STextBlock)
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 1
+							.TextStyle(&FAppStyle::Get().GetWidgetStyle<FTextBlockStyle>("NormalText"))
+#else
+							.TextStyle(&FEditorStyle::Get().GetWidgetStyle<FTextBlockStyle>("NormalText"))
+#endif
+							.Text(LOCTEXT("ConfigureLockRules", "Configure rules"))
+						]
+					]
 				]
 			]
 		]
@@ -589,6 +643,12 @@ TSharedPtr<SWidget> SPlasticSourceControlLocksWidget::OnOpenContextMenu()
 	);
 
 	return ToolMenus->GenerateWidget(Menu);
+}
+
+FReply SPlasticSourceControlLocksWidget::OnConfigureLockRulesClicked(const FString InOrganizationName)
+{
+	PlasticSourceControlUtils::OpenLockRulesInCloudDashboard(InOrganizationName);
+	return FReply::Handled();
 }
 
 void SPlasticSourceControlLocksWidget::OnReleaseLocksClicked(TArray<FPlasticSourceControlLockRef> InSelectedLocks)

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlLocksWidget.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlLocksWidget.h
@@ -48,6 +48,8 @@ private:
 
 	TSharedPtr<SWidget> OnOpenContextMenu();
 
+	FReply OnConfigureLockRulesClicked(const FString InOrganizationName);
+
 	void OnReleaseLocksClicked(TArray<FPlasticSourceControlLockRef> InSelectedLocks);
 	void OnRemoveLocksClicked(TArray<FPlasticSourceControlLockRef> InSelectedLocks);
 	void ExecuteUnlock(TArray<FPlasticSourceControlLockRef>&& InSelectedLocks, const bool bInRemove);


### PR DESCRIPTION
### What
Adds a new button to the new "View Locks" window to open Lock Rules in Unity's Dashboard if the workspace points to a cloud organization.

![image](https://github.com/PlasticSCM/UEPlasticPlugin/assets/101874327/ad5527ea-70c8-48d5-a8e4-d6e3e762e964)

### How
- Mutualize the function FPlasticSourceControlMenu::VisitLockRulesURLClicked() introduced in https://github.com/PlasticSCM/UEPlasticPlugin/pull/90
- Adds a new button that is only enabled if the Server URL of the current workspace points to a cloud organization
