### PR TITLE
Add the "--private" param to "cm checkin" and "cm partial checking"

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -468,14 +468,16 @@ bool FPlasticCheckInWorker::Execute(FPlasticSourceControlCommand& InCommand)
 			Parameters.Add(FString::Printf(TEXT("--commentsfile=\"%s\""), *CommitMsgFile.GetFilename()));
 			if (!GetProvider().IsPartialWorkspace())
 			{
-				Parameters.Add(TEXT("--all")); // Also files Changed (not CheckedOut) and Moved/Deleted Locally
+				Parameters.Add(TEXT("--all"));		// Also files Changed (not CheckedOut) and Moved/Deleted Locally
+				Parameters.Add(TEXT("--private"));	// Also Private files (not in source control)
 			//  NOTE: --update added as #23 but removed as #32 because most assets are locked by the Unreal Editor
 			//  Parameters.Add(TEXT("--update")); // Processes the update-merge automatically if it eventually happens.
 				InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("checkin"), Parameters, Files, InCommand.InfoMessages, InCommand.ErrorMessages);
 			}
 			else
 			{
-				Parameters.Add(TEXT("--applychanged")); // Also files Changed (not CheckedOut) and Moved/Deleted Locally
+				Parameters.Add(TEXT("--applychanged"));	// Also files Changed (not CheckedOut) and Moved/Deleted Locally
+				Parameters.Add(TEXT("--private"));		// Also Private files (not in source control)
 				InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("partial checkin"), Parameters, Files, InCommand.InfoMessages, InCommand.ErrorMessages);
 			}
 			if (InCommand.bCommandSuccessful)


### PR DESCRIPTION
Required to check-in Private files that are not already in source control