### PR TITLE
Fix for check in a tree of multiple private files and folders from the View Changes window in version 1.10.0

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -442,66 +442,65 @@ bool FPlasticCheckInWorker::Execute(FPlasticSourceControlCommand& InCommand)
 
 	const TArray<FString> Files = GetFilesFromCommand(GetProvider(), InCommand);
 
-	if (Files.Num() > 0)
-	{
-#if ENGINE_MAJOR_VERSION == 5
-		if (InCommand.Changelist.IsInitialized())
-		{
-			TSharedRef<FPlasticSourceControlChangelistState, ESPMode::ThreadSafe> ChangelistState = GetProvider().GetStateInternal(InCommand.Changelist);
-
-			if (Description.IsEmpty())
-			{
-				Description = ChangelistState->GetDescriptionText();
-			}
-
-			InChangelist = InCommand.Changelist;
-		}
-#endif
-
-		UE_LOG(LogSourceControl, Verbose, TEXT("CheckIn: %d file(s) Description: '%s'"), Files.Num(), *Description.ToString());
-
-		// make a temp file to place our commit message in
-		const FScopedTempFile CommitMsgFile(Description);
-		if (!CommitMsgFile.GetFilename().IsEmpty())
-		{
-			TArray<FString> Parameters;
-			Parameters.Add(FString::Printf(TEXT("--commentsfile=\"%s\""), *CommitMsgFile.GetFilename()));
-			Parameters.Add(TEXT("--all"));			// Also files Changed (not CheckedOut) and Moved/Deleted Locally
-			Parameters.Add(TEXT("--private"));		// Also Private files (not in source control)
-			Parameters.Add(TEXT("--dependencies"));	// Include all the dependent items automatically.
-			if (!GetProvider().IsPartialWorkspace())
-			{
-				//  NOTE: --update added as #23 but removed as #32 because most assets are locked by the Unreal Editor
-			//  Parameters.Add(TEXT("--update")); // Processes the update-merge automatically if it eventually happens.
-				InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("checkin"), Parameters, Files, InCommand.InfoMessages, InCommand.ErrorMessages);
-			}
-			else
-			{
-				InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("partial checkin"), Parameters, Files, InCommand.InfoMessages, InCommand.ErrorMessages);
-			}
-			if (InCommand.bCommandSuccessful)
-			{
-				Operation->SetSuccessMessage(PlasticSourceControlParsers::ParseCheckInResults(InCommand.InfoMessages));
-				UE_LOG(LogSourceControl, Log, TEXT("CheckIn successful"));
-			}
-
-#if ENGINE_MAJOR_VERSION == 5
-			if (InChangelist.IsInitialized() && !InChangelist.IsDefault())
-			{
-				// NOTE: we need to explicitly delete persistent changelists when we submit its content, except for the Default changelist
-				DeleteChangelist(GetProvider(), InChangelist, InCommand.InfoMessages, InCommand.ErrorMessages);
-			}
-#endif
-		}
-
-		// now update the status of our files
-		PlasticSourceControlUtils::InvalidateLocksCache();
-		PlasticSourceControlUtils::RunUpdateStatus(Files, PlasticSourceControlUtils::EStatusSearchType::ControlledOnly, false, InCommand.ErrorMessages, States, InCommand.ChangesetNumber, InCommand.BranchName);
-	}
-	else
+	if (Files.Num() == 0)
 	{
 		UE_LOG(LogSourceControl, Warning, TEXT("Checkin: No files provided"));
+		return false;
 	}
+
+#if ENGINE_MAJOR_VERSION == 5
+	if (InCommand.Changelist.IsInitialized())
+	{
+		TSharedRef<FPlasticSourceControlChangelistState, ESPMode::ThreadSafe> ChangelistState = GetProvider().GetStateInternal(InCommand.Changelist);
+
+		if (Description.IsEmpty())
+		{
+			Description = ChangelistState->GetDescriptionText();
+		}
+
+		InChangelist = InCommand.Changelist;
+	}
+#endif
+
+	UE_LOG(LogSourceControl, Verbose, TEXT("CheckIn: %d file(s) Description: '%s'"), Files.Num(), *Description.ToString());
+
+	// make a temp file to place our commit message in
+	const FScopedTempFile CommitMsgFile(Description);
+	if (!CommitMsgFile.GetFilename().IsEmpty())
+	{
+		TArray<FString> Parameters;
+		Parameters.Add(FString::Printf(TEXT("--commentsfile=\"%s\""), *CommitMsgFile.GetFilename()));
+		Parameters.Add(TEXT("--all"));			// Also files Changed (not CheckedOut) and Moved/Deleted Locally
+		Parameters.Add(TEXT("--private"));		// Also Private files (not in source control)
+		Parameters.Add(TEXT("--dependencies"));	// Include all the dependent items automatically.
+		if (!GetProvider().IsPartialWorkspace())
+		{
+			//  NOTE: --update added as #23 but removed as #32 because most assets are locked by the Unreal Editor
+		//  Parameters.Add(TEXT("--update")); // Processes the update-merge automatically if it eventually happens.
+			InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("checkin"), Parameters, Files, InCommand.InfoMessages, InCommand.ErrorMessages);
+		}
+		else
+		{
+			InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("partial checkin"), Parameters, Files, InCommand.InfoMessages, InCommand.ErrorMessages);
+		}
+		if (InCommand.bCommandSuccessful)
+		{
+			Operation->SetSuccessMessage(PlasticSourceControlParsers::ParseCheckInResults(InCommand.InfoMessages));
+			UE_LOG(LogSourceControl, Log, TEXT("CheckIn successful"));
+		}
+
+#if ENGINE_MAJOR_VERSION == 5
+		if (InChangelist.IsInitialized() && !InChangelist.IsDefault())
+		{
+			// NOTE: we need to explicitly delete persistent changelists when we submit its content, except for the Default changelist
+			DeleteChangelist(GetProvider(), InChangelist, InCommand.InfoMessages, InCommand.ErrorMessages);
+		}
+#endif
+	}
+
+	// now update the status of our files
+	PlasticSourceControlUtils::InvalidateLocksCache();
+	PlasticSourceControlUtils::RunUpdateStatus(Files, PlasticSourceControlUtils::EStatusSearchType::ControlledOnly, false, InCommand.ErrorMessages, States, InCommand.ChangesetNumber, InCommand.BranchName);
 
 	return InCommand.bCommandSuccessful;
 }


### PR DESCRIPTION
In version 1.10.0 the View Changes can show the local changes and private files in the Default changelist. It is possible to check in the changelist, but this will succeed only if there is a single new file in a private folder; it fails if the private folder contains multiple new files:
`LogSourceControl: ExecuteSynchronousCommand: CheckIn
LogSourceControl: Warning: RunCommand: 'checkin --commentsfile="C:/UnitySrc/UE53Plastic1100/Saved/Logs/Temp-702585FD4A268D2338CEB6BBD2B82A69.txt" --all --private --dependencies "c:/UnitySrc/UE53Plastic1100/Plugins/UEPlasticPlugin/PlasticSourceControl.uplugin" "c:/UnitySrc/UE53Plastic1100/Plugins' (in 0.292s) output (72 chars):
Error: An item with the same key has already been added. Key: /Plugins `

The issue needs to be worked around like for Perforce, by explicitly adding those files to source control before checking them in