### PR TITLE
Fix changelist files status of files outside content folder

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.cpp
@@ -1205,14 +1205,14 @@ static bool ParseChangelistsResults(const FXmlFile& InXmlResult, TArray<FPlastic
 	return true;
 }
 
-bool ParseChangelistsResults(const FString& Results, TArray<FPlasticSourceControlChangelistState>& OutChangelistsStates, TArray<TArray<FPlasticSourceControlState>>& OutCLFilesStates)
+bool ParseChangelistsResults(const FString& InResultFilename, TArray<FPlasticSourceControlChangelistState>& OutChangelistsStates, TArray<TArray<FPlasticSourceControlState>>& OutCLFilesStates)
 {
 	bool bResult = false;
 
 	FXmlFile XmlFile;
 	{
 		TRACE_CPUPROFILER_EVENT_SCOPE(PlasticSourceControlParsers::ParseChangelistsResults::FXmlFile::LoadFile);
-		bResult = XmlFile.LoadFile(Results, EConstructMethod::ConstructFromBuffer);
+		bResult = XmlFile.LoadFile(InResultFilename);
 	}
 	if (bResult)
 	{

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.h
@@ -72,7 +72,7 @@ FText ParseCheckInResults(const TArray<FString>& InResults);
 
 #if ENGINE_MAJOR_VERSION == 5
 
-bool ParseChangelistsResults(const FString& Results, TArray<FPlasticSourceControlChangelistState>& OutChangelistsStates, TArray<TArray<FPlasticSourceControlState>>& OutCLFilesStates);
+bool ParseChangelistsResults(const FString& InResultFilename, TArray<FPlasticSourceControlChangelistState>& OutChangelistsStates, TArray<TArray<FPlasticSourceControlState>>& OutCLFilesStates);
 
 bool ParseShelveDiffResult(const FString InWorkspaceRoot, TArray<FString>&& InResults, FPlasticSourceControlChangelistState& InOutChangelistsState);
 bool ParseShelveDiffResults(const FString InWorkspaceRoot, TArray<FString>&& InResults, TArray<FPlasticSourceControlRevision>& OutBaseRevisions);

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -765,7 +765,7 @@ bool RunUpdateStatus(const TArray<FString>& InFiles, const EStatusSearchType InS
 		// This should be an edge case (typically the uproject file) .
 		if (!bDirFound)
 		{
-			FString Path = FPaths::GetPath(File) + TEXT('/');
+			const FString Path = FPaths::GetPath(File) + TEXT('/');
 			FFilesInCommonDir* ExistingGroup = GroupOfFiles.Find(Path);
 			if (ExistingGroup != nullptr)
 			{
@@ -773,7 +773,7 @@ bool RunUpdateStatus(const TArray<FString>& InFiles, const EStatusSearchType InS
 			}
 			else
 			{
-				GroupOfFiles.Add(Path, { MoveTemp(Path), {File} });
+				GroupOfFiles.Add(Path, { Path, {File} });
 			}
 		}
 	}

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -947,6 +947,7 @@ bool RunGetChangelists(TArray<FPlasticSourceControlChangelistState>& OutChangeli
 
 	FString Results;
 	FString Errors;
+	const FScopedTempFile GetChangelistFile;
 	TArray<FString> Parameters;
 	Parameters.Add(TEXT("--changelists"));
 	Parameters.Add(TEXT("--controlledchanged"));
@@ -959,12 +960,12 @@ bool RunGetChangelists(TArray<FPlasticSourceControlChangelistState>& OutChangeli
 		Parameters.Add(TEXT("--private"));
 	}
 	Parameters.Add(TEXT("--noheader"));
-	Parameters.Add(TEXT("--xml"));
+	Parameters.Add(FString::Printf(TEXT("--xml=\"%s\""), *GetChangelistFile.GetFilename()));
 	Parameters.Add(TEXT("--encoding=\"utf-8\""));
 	bool bResult = RunCommand(TEXT("status"), Parameters, TArray<FString>(), Results, Errors);
 	if (bResult)
 	{
-		bResult = PlasticSourceControlParsers::ParseChangelistsResults(Results, OutChangelistsStates, OutCLFilesStates);
+		bResult = PlasticSourceControlParsers::ParseChangelistsResults(GetChangelistFile.GetFilename(), OutChangelistsStates, OutCLFilesStates);
 	}
 	if (!Errors.IsEmpty())
 	{


### PR DESCRIPTION
Context: trying to checking a whole tree of private files and folders through the View Changes, see related PR  #113 Fix for check in a tree of multiple private files and folders from the View Changes window in version 1.10.0