### PR TITLE
Fix RunCommand() to Append() to OutErrorMessages instead of erasing its content

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -51,8 +51,18 @@ bool RunCommand(const FString& InCommand, const TArray<FString>& InParameters, c
 
 	const bool bResult = PlasticSourceControlShell::RunCommand(InCommand, InParameters, InFiles, Results, Errors);
 
-	Results.ParseIntoArray(OutResults, PlasticSourceControlShell::pchDelim, true);
-	Errors.ParseIntoArray(OutErrorMessages, PlasticSourceControlShell::pchDelim, true);
+	if (!Results.IsEmpty())
+	{
+		TArray<FString> ParsedResults;
+		Results.ParseIntoArray(ParsedResults, PlasticSourceControlShell::pchDelim, true);
+		OutResults.Append(MoveTemp(ParsedResults));
+	}
+	if (!Errors.IsEmpty())
+	{
+		TArray<FString> ParsedErrors;
+		Errors.ParseIntoArray(ParsedErrors, PlasticSourceControlShell::pchDelim, true);
+		OutErrorMessages.Append(MoveTemp(ParsedErrors));
+	}
 
 	return bResult;
 }


### PR DESCRIPTION
Some operations run multiple commands, and we need to make sure that the success of one doesn't hide the failure of previous ones.

For example, when switching branches with local changes, updating workspace information after a failure prevented the notification from displaying the reason!