### PR TITLE
Fix FPlasticSourceControlProvider::UsesFileRevisions() for UE5.5

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
@@ -532,10 +532,13 @@ bool FPlasticSourceControlProvider::UsesCheckout() const
 
 bool FPlasticSourceControlProvider::UsesFileRevisions() const
 {
-	// This API introduced in UE5.1 is still broken as of UE5.3
+	// This API introduced in UE5.1 was broken until they finally merged our PR in UE5.5
 	// (preventing the user to use the source control context menu for checkin if returning false)
-	// return IsPartialWorkspace();
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5
+	return IsPartialWorkspace();
+#else
 	return true;
+#endif
 }
 
 bool FPlasticSourceControlProvider::UsesSnapshots() const


### PR DESCRIPTION
This API introduced in UE5.1 was broken, preventing the user to use the source control context menu for checkin if returning false It's finally been fixed by merging our PR in ue5-main for UE5.5

So now we can return IsPartialWorkspace(); so the "context update workspace" allowing to update just a selection of files only applies to partial Gluon workspaces