### PR TITLE
Fix handling of repository names containing spaces

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -1113,11 +1113,13 @@ bool FPlasticMakeWorkspaceWorker::Execute(FPlasticSourceControlCommand& InComman
 	TSharedRef<FPlasticMakeWorkspace, ESPMode::ThreadSafe> Operation = StaticCastSharedRef<FPlasticMakeWorkspace>(InCommand.Operation);
 
 	{
+		// cm repository "<repserverspec>" "<rep_name>"
 		TArray<FString> Parameters;
+		Parameters.Add(TEXT("create"));
 		Parameters.Add(Operation->ServerUrl);
 		Parameters.Add(FString::Printf(TEXT("\"%s\""), *Operation->RepositoryName));
-		// Note: the whole operation should fail entirely if the repository creation failed (if the repository already exists, if the organization name is invalid, credential, autorizations etc.)
-		InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("makerepository"), Parameters, TArray<FString>(), InCommand.InfoMessages, InCommand.ErrorMessages);
+		// Note: the whole operation should fail entirely if the repository creation failed (if the repository already exists, if the organization name is invalid, credential, authorizations etc.)
+		InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("repository"), Parameters, TArray<FString>(), InCommand.InfoMessages, InCommand.ErrorMessages);
 		// Specifically detect the specific error when the organization name is invalid, and add an more human readable message.
 		if (InCommand.ErrorMessages.Contains(TEXT("Can't resolve DNS entry for cloud.plasticscm.com")))
 		{
@@ -1126,11 +1128,13 @@ bool FPlasticMakeWorkspaceWorker::Execute(FPlasticSourceControlCommand& InComman
 	}
 	if (InCommand.bCommandSuccessful)
 	{
+		// cm workspace create <wk_name> <wk_path> [<rep_spec>]
 		TArray<FString> Parameters;
+		Parameters.Add(TEXT("create"));
 		Parameters.Add(FString::Printf(TEXT("\"%s\""), *Operation->WorkspaceName));
 		Parameters.Add(TEXT(".")); // current path, ie. ProjectDir
-		Parameters.Add(FString::Printf(TEXT("--repository=\"rep:%s@repserver:%s\""), *Operation->RepositoryName, *Operation->ServerUrl));
-		InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("makeworkspace"), Parameters, TArray<FString>(), InCommand.InfoMessages, InCommand.ErrorMessages);
+		Parameters.Add(FString::Printf(TEXT("\"rep:%s@repserver:%s\""), *Operation->RepositoryName, *Operation->ServerUrl));
+		InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("workspace"), Parameters, TArray<FString>(), InCommand.InfoMessages, InCommand.ErrorMessages);
 	}
 	if (InCommand.bCommandSuccessful && Operation->bPartialWorkspace)
 	{

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -1115,7 +1115,7 @@ bool FPlasticMakeWorkspaceWorker::Execute(FPlasticSourceControlCommand& InComman
 	{
 		TArray<FString> Parameters;
 		Parameters.Add(Operation->ServerUrl);
-		Parameters.Add(Operation->RepositoryName);
+		Parameters.Add(FString::Printf(TEXT("\"%s\""), *Operation->RepositoryName));
 		// Note: the whole operation should fail entirely if the repository creation failed (if the repository already exists, if the organization name is invalid, credential, autorizations etc.)
 		InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("makerepository"), Parameters, TArray<FString>(), InCommand.InfoMessages, InCommand.ErrorMessages);
 		// Specifically detect the specific error when the organization name is invalid, and add an more human readable message.
@@ -1127,9 +1127,9 @@ bool FPlasticMakeWorkspaceWorker::Execute(FPlasticSourceControlCommand& InComman
 	if (InCommand.bCommandSuccessful)
 	{
 		TArray<FString> Parameters;
-		Parameters.Add(Operation->WorkspaceName);
+		Parameters.Add(FString::Printf(TEXT("\"%s\""), *Operation->WorkspaceName));
 		Parameters.Add(TEXT(".")); // current path, ie. ProjectDir
-		Parameters.Add(FString::Printf(TEXT("--repository=rep:%s@repserver:%s"), *Operation->RepositoryName, *Operation->ServerUrl));
+		Parameters.Add(FString::Printf(TEXT("--repository=\"rep:%s@repserver:%s\""), *Operation->RepositoryName, *Operation->ServerUrl));
 		InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("makeworkspace"), Parameters, TArray<FString>(), InCommand.InfoMessages, InCommand.ErrorMessages);
 	}
 	if (InCommand.bCommandSuccessful && Operation->bPartialWorkspace)

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -520,7 +520,7 @@ bool RunListLocks(const FPlasticSourceControlProvider& InProvider, const bool bI
 	Parameters.Add(TEXT("list"));
 	Parameters.Add(TEXT("--machinereadable"));
 	Parameters.Add(TEXT("--smartlocks"));
-	Parameters.Add(FString::Printf(TEXT("--repository=%s"), *InProvider.GetRepositoryName()));
+	Parameters.Add(FString::Printf(TEXT("--repository=\"%s\""), *InProvider.GetRepositoryName()));
 	Parameters.Add(TEXT("--anystatus"));
 	Parameters.Add(TEXT("--fieldseparator=\"") FILE_STATUS_SEPARATOR TEXT("\""));
 	// NOTE: --dateformat was added to smartlocks a couple of releases later in version 11.0.16.8133

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -529,7 +529,7 @@ bool RunListLocks(const FPlasticSourceControlProvider& InProvider, const bool bI
 	if (!bInForAllDestBranches && (InProvider.GetPlasticScmVersion() >= PlasticSourceControlVersions::WorkingBranch))
 	{
 		// Note: here is one of the rare places where we need to use a branch name, not a workspace selector
-		Parameters.Add(FString::Printf(TEXT("--workingbranch=%s"), *InProvider.GetBranchName()));
+		Parameters.Add(FString::Printf(TEXT("--workingbranch=\"%s\""), *InProvider.GetBranchName()));
 	}
 	const bool bResult = RunCommand(TEXT("lock"), Parameters, TArray<FString>(), Results, ErrorMessages);
 


### PR DESCRIPTION
Currently the Unreal Plugin doesn't handle correctly name of repository containing spaces!

Create Repository failing:

```
LogSourceControl: CreatePlasticWorkspace(Unreal Workspace, Unreal Repository, SRombautsU@cloud) PartialWorkspace=0 CreateIgnore=0 Commit=1
LogSourceControl: IssueAsynchronousCommand: MakeWorkspace
LogSourceControl: RunCommand: 'makerepository SRombautsU@cloud Unreal Repository' (in 0.332s) output (0 chars):
LogSourceControl: Warning: RunCommand: 'makeworkspace Unreal Workspace . --repository=rep:Unreal Repository@repserver:SRombautsU@cloud' (in 0.871s) output (48 chars):
The specified repository couldn't be found: ..
SourceControl: Error: Command: MakeWorkspace, Error: The specified repository couldn't be found: ..
LogSourceControl: MakeWorkspace processed in 1.218s
LogSourceControl: Error: Error: MakeWorkspace operation failed!
The specified repository couldn't be found: ..
```

Lock List failing:

```
LogSourceControl: IssueAsynchronousCommand: GetLocks
LogSourceControl: Warning: RunCommand: 'lock list --machinereadable --smartlocks --repository=Unreal Repository --anystatus --fieldseparator=";" --dateformat=yyyy-MM-ddTHH:mm:ss' (in 0.081s) output (64 chars):
The specified repository couldn't be found: Unreal
```

We have to make sure that all commands to the cli use quotes around the repository specs.


