### PR TITLE
Add support for Unreal Engine 5.5

### DIFF
--- a/Source/PlasticSourceControl/Private/PackageUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PackageUtils.cpp
@@ -10,6 +10,8 @@
 #include "PackageTools.h"
 #include "UObject/Linker.h"
 
+#include "Runtime/Launch/Resources/Version.h"
+
 namespace PackageUtils
 {
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlChangelist.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlChangelist.cpp
@@ -1,8 +1,8 @@
 // Copyright (c) 2024 Unity Technologies
 
-#if ENGINE_MAJOR_VERSION == 5
-
 #include "PlasticSourceControlChangelist.h"
+
+#if ENGINE_MAJOR_VERSION == 5
 
 const FPlasticSourceControlChangelist FPlasticSourceControlChangelist::DefaultChangelist(TEXT("Default"), true);
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlChangelistState.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlChangelistState.cpp
@@ -1,8 +1,8 @@
 // Copyright (c) 2024 Unity Technologies
 
-#if ENGINE_MAJOR_VERSION == 5
-
 #include "PlasticSourceControlChangelistState.h"
+
+#if ENGINE_MAJOR_VERSION == 5
 
 #define LOCTEXT_NAMESPACE "PlasticSourceControl.ChangelistState"
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.cpp
@@ -1334,7 +1334,11 @@ bool ParseShelveDiffResult(const FString InWorkspaceRoot, TArray<FString>&& InRe
 		EWorkspaceState ShelveState = ParseShelveFileStatus(Result[0]);
 
 		// Remove outer double quotes
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5
+		Result.MidInline(3, Result.Len() - 4, EAllowShrinking::No);
+#else
 		Result.MidInline(3, Result.Len() - 4, false);
+#endif
 
 		FString MovedFrom;
 		if (ShelveState == EWorkspaceState::Moved)
@@ -1485,7 +1489,11 @@ bool ParseShelveDiffResults(const FString InWorkspaceRoot, TArray<FString>&& InR
 			const int32 BaseRevisionId = FCString::Atoi(*ResultElements[1]);
 			// Remove outer double quotes on filename
 			FString File = MoveTemp(ResultElements[2]);
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5
+			File.MidInline(1, File.Len() - 2, EAllowShrinking::No);
+#else
 			File.MidInline(1, File.Len() - 2, false);
+#endif
 			FString AbsoluteFilename = FPaths::ConvertRelativePathToFull(InWorkspaceRoot, File);
 
 			if (ShelveState == EWorkspaceState::Moved)

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlStyle.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlStyle.cpp
@@ -6,6 +6,8 @@
 #include "Interfaces/IPluginManager.h"
 #include "Slate/SlateGameResources.h"
 #include "Styling/SlateStyle.h"
+
+#include "Runtime/Launch/Resources/Version.h"
 #if ENGINE_MAJOR_VERSION >= 5
 #include "Styling/SlateStyleMacros.h"
 #endif

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -432,7 +432,11 @@ static bool RunStatus(const FString& InDir, TArray<FString>&& InFiles, const ESt
 		if (Results.Num() > 0)
 		{
 			PlasticSourceControlParsers::GetChangesetFromWorkspaceStatus(Results, OutChangeset);
+#if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 5
+			Results.RemoveAt(0, EAllowShrinking::No);
+#else
 			Results.RemoveAt(0, 1, false);
+#endif
 		}
 
 		// Normalize file paths in the result (convert all '\' to '/')

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtilsTests.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtilsTests.cpp
@@ -6,7 +6,7 @@
 #if !(UE_BUILD_SHIPPING || UE_BUILD_TEST)
 #include "Misc/AutomationTest.h"
 
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(FFindCommonDirectoryUnitTest, "PlasticSCM.FindCommonDirectory", EAutomationTestFlags::ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FFindCommonDirectoryUnitTest, "PlasticSCM.FindCommonDirectory", EAutomationTestFlags::EditorContext | EAutomationTestFlags::CommandletContext | EAutomationTestFlags::ProductFilter)
 
 bool FFindCommonDirectoryUnitTest::RunTest(const FString& Parameters)
 {
@@ -40,7 +40,7 @@ bool FFindCommonDirectoryUnitTest::RunTest(const FString& Parameters)
 	return true; // actual results are returned by TestXxx() macros
 }
 
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSoftwareVersionUnitTest, "PlasticSCM.SoftwareVersion", EAutomationTestFlags::ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSoftwareVersionUnitTest, "PlasticSCM.SoftwareVersion", EAutomationTestFlags::EditorContext | EAutomationTestFlags::CommandletContext | EAutomationTestFlags::ProductFilter)
 
 bool FSoftwareVersionUnitTest::RunTest(const FString& Parameters)
 {
@@ -56,7 +56,7 @@ bool FSoftwareVersionUnitTest::RunTest(const FString& Parameters)
 	return true; // actual results are returned by TestXxx() macros
 }
 
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSoftwareVersionEqualUnitTest, "PlasticSCM.SoftwareVersionEqual", EAutomationTestFlags::ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSoftwareVersionEqualUnitTest, "PlasticSCM.SoftwareVersionEqual", EAutomationTestFlags::EditorContext | EAutomationTestFlags::CommandletContext | EAutomationTestFlags::ProductFilter)
 
 bool FSoftwareVersionEqualUnitTest::RunTest(const FString& Parameters)
 {
@@ -75,7 +75,7 @@ bool FSoftwareVersionEqualUnitTest::RunTest(const FString& Parameters)
 	return true; // actual results are returned by TestXxx() macros
 }
 
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSoftwareVersionLessUnitTest, "PlasticSCM.SoftwareVersionLess", EAutomationTestFlags::ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSoftwareVersionLessUnitTest, "PlasticSCM.SoftwareVersionLess", EAutomationTestFlags::EditorContext | EAutomationTestFlags::CommandletContext | EAutomationTestFlags::ProductFilter)
 
 bool FSoftwareVersionLessUnitTest::RunTest(const FString& Parameters)
 {
@@ -121,7 +121,7 @@ bool FSoftwareVersionLessUnitTest::RunTest(const FString& Parameters)
 	return true; // actual results are returned by TestXxx() macros
 }
 
-IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSoftwareVersionMoreOrEqualUnitTest, "PlasticSCM.SoftwareVersionMoreOrEqual", EAutomationTestFlags::ApplicationContextMask | EAutomationTestFlags::ProductFilter)
+IMPLEMENT_SIMPLE_AUTOMATION_TEST(FSoftwareVersionMoreOrEqualUnitTest, "PlasticSCM.SoftwareVersionMoreOrEqual", EAutomationTestFlags::EditorContext | EAutomationTestFlags::CommandletContext | EAutomationTestFlags::ProductFilter)
 
 bool FSoftwareVersionMoreOrEqualUnitTest::RunTest(const FString& Parameters)
 {


### PR DESCRIPTION
 * New APIS in UE5.5 for RemoveAt(0, EAllowShrinking::No) and MidInline(3, x, EAllowShrinking::No);
   * Note: change taken from upstream in-engine plugin so we don't diverge more than needed
 * Fix UE5.5 missing definitions of ENGINE_MAJOR_VERSION
   * Add 2 missing #include "Runtime/Launch/Resources/Version.h"
   * Move 2 #if ENGINE_MAJOR_VERSION == 5 after the include of the header, that in turn includes the needed "Version.h"
 * Fix unit test compilation with UE5.5 Replace the bitmask EAutomationTestFlags::ApplicationContextMask that was removed from the Engine with a more precise EAutomationTestFlags::EditorContext | EAutomationTestFlags::CommandletContext
