### PR TITLE
Fix lock cache excessive calls

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProjectSettings.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProjectSettings.h
@@ -29,6 +29,10 @@ public:
 	UPROPERTY(config, EditAnywhere, Category = "Unity Version Control", meta = (ClampMin = 0))
 	int32 LimitNumberOfRevisionsInHistory = 50;
 
+	/** Set an expiration time in minutes for the cache of SmartLocks, after which they need to be retrieved again from the server (default to 5 min) */
+	UPROPERTY(config, EditAnywhere, Category = "Unity Version Control", meta = (ClampMin = 1))
+	double LocksCacheExpirationDelayMinutes = 5.0;
+
 	/** Show the repository where the branch is created (hidden by default) */
 	UPROPERTY(config, EditAnywhere, Category = "Unity Version Control|View Branches window")
 	bool bShowBranchRepositoryColumn = false;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlShell.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlShell.cpp
@@ -55,7 +55,6 @@ static FORCEINLINE bool CreatePipeWrite(void*& ReadPipe, void*& WritePipe)
 namespace PlasticSourceControlShell
 {
 static const TCHAR* ShellCommandResultText = TEXT("CommandResult ");
-static const TCHAR* ShellUserInteractText = TEXT("Select your system [0-1]");
 
 // In/Out Pipes for the 'cm shell' persistent child process
 static void*			ShellOutputPipeRead = nullptr;
@@ -268,18 +267,6 @@ static bool _RunCommandInternal(const FString& InCommand, const TArray<FString>&
 					OutResults.RemoveAt(IndexCommandResult, OutResults.Len() - IndexCommandResult);
 					break;
 				}
-			}
-
-			// Search the output for a potential user interaction request (in case the authentication token isn't saved or valid anymore)
-			const uint32 IndexPrompt = OutResults.Find(ShellUserInteractText, ESearchCase::CaseSensitive, ESearchDir::FromEnd);
-			if (INDEX_NONE != IndexPrompt)
-			{
-				const FText ShellRequiresInteractionError(LOCTEXT("SourceControlShell_AskAuthenticate", "Unity Version Control command line requires user interaction.\nSign in using the Unity Version Control client."));
-				FNotification::DisplayFailure(ShellRequiresInteractionError);
-
-				// Restart the shell without waiting, it is forever blocked waiting for user input
-				_RestartBackgroundCommandLineShell(true);
-				break; // and quit the loop
 			}
 		}
 		else if ((FPlatformTime::Seconds() - LastLog > LogInterval) && (PreviousLogLen < OutResults.Len()))

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlShell.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlShell.cpp
@@ -243,7 +243,7 @@ static bool _RunCommandInternal(const FString& InCommand, const TArray<FString>&
 	const double StartTimestamp = FPlatformTime::Seconds();
 	double LastActivity = StartTimestamp;
 	double LastLog = StartTimestamp;
-	static const double LogInterval = 5.0;
+	static const double LogInterval = 10.0; // log interval for long running operation
 	int32 PreviousLogLen = 0;
 	while (FPlatformProcess::IsProcRunning(ShellProcessHandle))
 	{
@@ -285,14 +285,14 @@ static bool _RunCommandInternal(const FString& InCommand, const TArray<FString>&
 		else if ((FPlatformTime::Seconds() - LastLog > LogInterval) && (PreviousLogLen < OutResults.Len()))
 		{
 			// In case of long running operation, start to print intermediate output from cm shell (like percentage of progress)
-			UE_LOG(LogSourceControl, Log, TEXT("RunCommand: '%s' in progress for %.3lfs... (%d chars):\n%s"), *InCommand, (FPlatformTime::Seconds() - StartTimestamp), OutResults.Len() - PreviousLogLen, *OutResults.Mid(PreviousLogLen));
+			UE_LOG(LogSourceControl, Log, TEXT("RunCommand: '%s' in progress for %.3lfs... (%d chars):\n%s"), *InCommand, (FPlatformTime::Seconds() - StartTimestamp), OutResults.Len() - PreviousLogLen, *OutResults.Mid(PreviousLogLen, 4096)); // Limit result size to 4096 characters
 			PreviousLogLen = OutResults.Len();
 			LastLog = FPlatformTime::Seconds(); // freshen the timestamp of last log
 		}
 		else if (FPlatformTime::Seconds() - LastActivity > Timeout)
 		{
 			// In case of timeout, ask the blocking 'cm shell' process to exit, detach from it and restart it immediately
-			UE_LOG(LogSourceControl, Error, TEXT("RunCommand: '%s' TIMEOUT after %.3lfs output (%d chars):\n%s"), *InCommand, (FPlatformTime::Seconds() - StartTimestamp), OutResults.Len(), *OutResults.Mid(PreviousLogLen));
+			UE_LOG(LogSourceControl, Error, TEXT("RunCommand: '%s' TIMEOUT after %.3lfs output (%d chars):\n%s"), *InCommand, (FPlatformTime::Seconds() - StartTimestamp), OutResults.Len(), *OutResults.Mid(PreviousLogLen, 4096)); // Limit result size to 4096 characters
 			_RestartBackgroundCommandLineShell(true);
 			// Return output results as error so they get propagated to the Message Log window
 			OutErrors = MoveTemp(OutResults);
@@ -300,7 +300,7 @@ static bool _RunCommandInternal(const FString& InCommand, const TArray<FString>&
 		}
 		else if (IsEngineExitRequested())
 		{
-			UE_LOG(LogSourceControl, Warning, TEXT("RunCommand: '%s' Engine Exit was requested after %.3lfs output (%d chars):\n%s"), *InCommand, (FPlatformTime::Seconds() - StartTimestamp), OutResults.Len() - PreviousLogLen, *OutResults.Mid(PreviousLogLen));
+			UE_LOG(LogSourceControl, Warning, TEXT("RunCommand: '%s' Engine Exit was requested after %.3lfs output (%d chars):\n%s"), *InCommand, (FPlatformTime::Seconds() - StartTimestamp), OutResults.Len() - PreviousLogLen, *OutResults.Mid(PreviousLogLen, 4096)); // Limit result size to 4096 characters
 			_ExitBackgroundCommandLineShell();
 		}
 
@@ -314,17 +314,17 @@ static bool _RunCommandInternal(const FString& InCommand, const TArray<FString>&
 		if (!FPlatformProcess::IsProcRunning(ShellProcessHandle))
 		{
 			// 'cm shell' normally only terminates in case of 'exit' command. Will restart on next command.
-			UE_LOG(LogSourceControl, Error, TEXT("RunCommand: '%s' 'cm shell' stopped after %.3lfs output (%d chars):\n%s"), *LoggableCommand, ElapsedTime, OutResults.Len(), *OutResults.Left(4096)); // Limit result size to 4096 characters
+			UE_LOG(LogSourceControl, Error, TEXT("RunCommand: '%s' 'cm shell' stopped after %.3lfs output (%d chars):\n%s"), *LoggableCommand, ElapsedTime, OutResults.Len(), *OutResults.Left(200)); // Limit long running intermediate log to 200 characters
 		}
 		else if (!bResult)
 		{
-			UE_LOG(LogSourceControl, Warning, TEXT("RunCommand: '%s' (in %.3lfs) output (%d chars):\n%s"), *LoggableCommand, ElapsedTime, OutResults.Len(), *OutResults.Left(4096)); // Limit result size to 4096 characters
+			UE_LOG(LogSourceControl, Warning, TEXT("RunCommand: '%s' (in %.3lfs) output (%d chars):\n%s"), *LoggableCommand, ElapsedTime, OutResults.Len(), *OutResults.Right(4096)); // Limit result size to 4096 characters
 		}
 		else
 		{
 			if (PreviousLogLen > 0)
 			{
-				UE_LOG(LogSourceControl, Log, TEXT("RunCommand: '%s' (in %.3lfs) output (%d chars):\n%s"), *LoggableCommand, ElapsedTime, OutResults.Len(), *OutResults.Mid(PreviousLogLen).Left(4096)); // Limit result size to 4096 characters
+				UE_LOG(LogSourceControl, Log, TEXT("RunCommand: '%s' (in %.3lfs) output (%d chars):\n%s"), *LoggableCommand, ElapsedTime, OutResults.Len(), *OutResults.Mid(PreviousLogLen).Right(200)); // Limit long running intermediate log to 200 characters
 			}
 			else
 			{

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlShell.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlShell.cpp
@@ -253,8 +253,8 @@ static bool _RunCommandInternal(const FString& InCommand, const TArray<FString>&
 
 			LastActivity = FPlatformTime::Seconds(); // freshen the timestamp while cm is still actively outputting information
 			OutResults.Append(MoveTemp(Output));
-			// Search the output for the line containing the result code, also indicating the end of the command
-			const uint32 IndexCommandResult = OutResults.Find(ShellCommandResultText, ESearchCase::CaseSensitive, ESearchDir::FromEnd);
+			// Search the output for the line containing the result code, also indicating the end of the command (only search in the last few characters, for approximately the last line)
+			const uint32 IndexCommandResult = OutResults.Find(ShellCommandResultText, ESearchCase::CaseSensitive, ESearchDir::FromStart, OutResults.Len() - 20);
 			if (INDEX_NONE != IndexCommandResult)
 			{
 				const uint32 IndexEndResult = OutResults.Find(pchDelim, ESearchCase::CaseSensitive, ESearchDir::FromStart, IndexCommandResult + 14);

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -482,7 +482,7 @@ public:
 	{
 		FScopeLock Lock(&CriticalSection);
 		const FTimespan ElapsedTime = FDateTime::Now() - Timestamp;
-		if (ElapsedTime.GetTotalSeconds() < 60.0)
+		if (ElapsedTime.GetTotalMinutes() < GetDefault<UPlasticSourceControlProjectSettings>()->LocksCacheExpirationDelayMinutes)
 		{
 			OutLocks = Locks;
 			return true;


### PR DESCRIPTION
Fix poor performance due to excessive Lock List calls despite the cache set in place to reduce their amount.

1. Fix the excessive lock calls due to a bad usage of a CriticalSection
2. Fix the performances due to the exponential complexity of cm shell output text parsing
3. Let the user change lock cache expiration delay and increase the default value from 1 to 5 minutes
4. Improve the logs, by limiting some and adding missing ones
.