### PR TITLE
Update README file to highlight support of Unreal Engine 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ Unity Version Control (formerly Plastic SCM) plugin for Unreal Engine
 
 [![release](https://img.shields.io/github/release/PlasticSCM/UEPlasticPlugin.svg)](https://github.com/PlasticSCM/UEPlasticPlugin/releases)
 
-This is the **official [Unity Version Control (formerly Plastic SCM)](https://unity.com/solutions/version-control) plugin for Unreal Engine** (UE 4.11 to 4.27, and UE 5.0 to 5.4).
+This is the **official [Unity Version Control (formerly Plastic SCM)](https://unity.com/solutions/version-control) plugin for Unreal Engine 5** (UE 5.0 to 5.5) with previous releases also supporting UE4.27.
 
-It is now [distributed in the Unreal Engine Marketplace as a Code Plugin, supporting Engine Versions 5.1 to 5.3 on Windows. ![Unity Version Control in the Unreal Engine Marketplace](Screenshots/Marketplace_UnityVersionControl.png)](https://www.unrealengine.com/marketplace/product/unity-version-control-plastic-scm)
+It is now [distributed in the Unreal Engine Marketplace as a Code Plugin, supporting Engine Versions 5.1 to 5.4 on Windows. ![Unity Version Control in the Unreal Engine Marketplace](Screenshots/Marketplace_UnityVersionControl.png)](https://www.unrealengine.com/marketplace/product/unity-version-control-plastic-scm)
 
 As a general rule, the Marketplace and GitHub versions of the plugin will always be the most up-to-date and recent versions.
 They're easier for us to patch by applying a hotfix, in case a bug is raised and something broken must be fixed quickly.
@@ -104,7 +104,7 @@ They're easier for us to patch by applying a hotfix, in case a bug is raised and
 
 [![release](https://img.shields.io/github/release/PlasticSCM/UEPlasticPlugin.svg)](https://github.com/PlasticSCM/UEPlasticPlugin/releases)
 
- 1. Download the [latest binary release UE5PlasticPlugin-x.x.x.zip](https://github.com/PlasticSCM/UEPlasticPlugin/releases) targeting your UE5 version (resp UE4).
+ 1. Download the [latest binary release UE5PlasticPlugin-x.x.x.zip](https://github.com/PlasticSCM/UEPlasticPlugin/releases) targeting your UE5 version.
  2. Either:
      1. Unzip the content of the ZIP directly at the root of your project folder.
         This creates a "Plugins\UEPlasticPlugin\" subdirectory into your project.
@@ -328,14 +328,6 @@ Plastic SCM forums:
  12. **Merge conflict**, the asset has been changed in two separate branches and is pending merge resolution
 
 #### Revision Control Menu
-
-##### Unreal Engine 4 Source Control Menu
-
-Source Control status tooltip, when hovering the Source Control icon in toolbar:  
-![Source Control Status Tooltip](Screenshots/UE4PlasticPlugin-SourceControlStatus.png)
-
-Source Control top Menu, extended with commands specific to Unity Version Control:  
-![Source Control Top Menu](Screenshots/UE4PlasticPlugin-SourceControlMenu.png)
 
 ##### Unreal Engine 5 Revision Control Menu
 
@@ -590,10 +582,6 @@ eg:
 
     "C:\Program Files\Epic Games\UE_5.2\Engine\Binaries\Win64\UnrealEditor.exe" "C:\UnitySrc\UE5UnityVCSDevEnv\UE5UnityVCSDevEnv.uproject" -diff "@sourcefile" "@destinationfile"
 
-or for Unreal Engine 4:
-
-    "C:\Program Files\Epic Games\UE_4.27\Engine\Binaries\Win64\UE4Editor.exe" "C:\wkspaces\ProjectName\ProjectName.uproject" -diff "@sourcefile" "@destinationfile"
-
 #### Text Diff of any assets
 
 To configure a text diff for any uasset (not only Blueprints) use this command instead
@@ -705,7 +693,7 @@ If you want to help, [Github Pull Requests](https://github.com/PlasticSCM/UEPlas
 
 ## Source code architecture
 
-See also [Unreal Engine C++ Coding Standard](https://docs.unrealengine.com/4.27/en-US/ProductionPipelines/DevelopmentSetup/CodingStandard/)
+See also [Unreal Engine C++ Coding Standard](https://dev.epicgames.com/documentation/en-us/unreal-engine/epic-cplusplus-coding-standard-for-unreal-engine)
 
 All the relevant C++ source code of the plugin reside in one subdirectory `<ProjectName>/Plugins/UEPlasticPlugin/Source/PlasticSourceControl/Private/`
 


### PR DESCRIPTION
Just remove a few outdated reference and screenshots of UE4, but only when there is already a UE5 replacement (ie. when there was a meaningful difference, in some menus mainly)

In the future it would be nice to redo some outdated screenshots so we have a higher coherence.