### PR TITLE
Improve create repository window for unity orgs

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -1131,11 +1131,6 @@ bool FPlasticMakeWorkspaceWorker::Execute(FPlasticSourceControlCommand& InComman
 		Parameters.Add(FString::Printf(TEXT("\"%s\""), *Operation->RepositoryName));
 		// Note: the whole operation should fail entirely if the repository creation failed (if the repository already exists, if the organization name is invalid, credential, authorizations etc.)
 		InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunCommand(TEXT("repository"), Parameters, TArray<FString>(), InCommand.InfoMessages, InCommand.ErrorMessages);
-		// Specifically detect the specific error when the organization name is invalid, and add an more human readable message.
-		if (InCommand.ErrorMessages.Contains(TEXT("Can't resolve DNS entry for cloud.plasticscm.com")))
-		{
-			InCommand.ErrorMessages.Add(TEXT("Invalid cloud organization name."));
-		}
 	}
 	if (InCommand.bCommandSuccessful)
 	{

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.cpp
@@ -60,6 +60,7 @@ void IPlasticSourceControlWorker::RegisterWorkers(FPlasticSourceControlProvider&
 	PlasticSourceControlProvider.RegisterWorker("DeleteBranches", FGetPlasticSourceControlWorker::CreateStatic(&InstantiateWorker<FPlasticDeleteBranchesWorker>));
 	PlasticSourceControlProvider.RegisterWorker("GetChangesets", FGetPlasticSourceControlWorker::CreateStatic(&InstantiateWorker<FPlasticGetChangesetsWorker>));
 	PlasticSourceControlProvider.RegisterWorker("GetChangesetFiles", FGetPlasticSourceControlWorker::CreateStatic(&InstantiateWorker<FPlasticGetChangesetFilesWorker>));
+	PlasticSourceControlProvider.RegisterWorker("GetProjects", FGetPlasticSourceControlWorker::CreateStatic(&InstantiateWorker<FPlasticGetProjectsWorker>));
 	PlasticSourceControlProvider.RegisterWorker("MakeWorkspace", FGetPlasticSourceControlWorker::CreateStatic(&InstantiateWorker<FPlasticMakeWorkspaceWorker>));
 	PlasticSourceControlProvider.RegisterWorker("Sync", FGetPlasticSourceControlWorker::CreateStatic(&InstantiateWorker<FPlasticSyncWorker>));
 	PlasticSourceControlProvider.RegisterWorker("SyncAll", FGetPlasticSourceControlWorker::CreateStatic(&InstantiateWorker<FPlasticSyncWorker>));
@@ -261,6 +262,16 @@ FName FPlasticGetChangesetFiles::GetName() const
 FText FPlasticGetChangesetFiles::GetInProgressString() const
 {
 	return FText::Format(LOCTEXT("SourceControl_GetChangesetFiles", "Getting the list of files in changeset {0}..."), FText::AsNumber(Changeset->ChangesetId));
+}
+
+FName FPlasticGetProjects::GetName() const
+{
+	return "GetProjects";
+}
+
+FText FPlasticGetProjects::GetInProgressString() const
+{
+	return FText::Format(LOCTEXT("SourceControl_GetProjects", "Getting the projects in {0}..."), FText::FromString(ServerUrl));
 }
 
 
@@ -1460,7 +1471,6 @@ bool FPlasticGetChangesetsWorker::UpdateStates()
 }
 
 
-
 FName FPlasticGetChangesetFilesWorker::GetName() const
 {
 	return "GetChangesetFiles";
@@ -1490,6 +1500,29 @@ bool FPlasticGetChangesetFilesWorker::Execute(FPlasticSourceControlCommand& InCo
 }
 
 bool FPlasticGetChangesetFilesWorker::UpdateStates()
+{
+	return false;
+}
+
+
+FName FPlasticGetProjectsWorker::GetName() const
+{
+	return "GetProjects";
+}
+
+bool FPlasticGetProjectsWorker::Execute(FPlasticSourceControlCommand& InCommand)
+{
+	TRACE_CPUPROFILER_EVENT_SCOPE(FPlasticGetProjectsWorker::Execute);
+
+	check(InCommand.Operation->GetName() == GetName());
+	TSharedRef<FPlasticGetProjects, ESPMode::ThreadSafe> Operation = StaticCastSharedRef<FPlasticGetProjects>(InCommand.Operation);
+
+    InCommand.bCommandSuccessful = PlasticSourceControlUtils::RunGetProjects(Operation->ServerUrl, Operation->ProjectNames, InCommand.ErrorMessages);
+
+	return InCommand.bCommandSuccessful;
+}
+
+bool FPlasticGetProjectsWorker::UpdateStates()
 {
 	return false;
 }

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
@@ -304,6 +304,24 @@ public:
 };
 
 
+/**
+ * Internal operation to list projects from a Unity organization
+*/
+class FPlasticGetProjects final : public FSourceControlOperationBase
+{
+public:
+	// ISourceControlOperation interface
+	virtual FName GetName() const override;
+
+	virtual FText GetInProgressString() const override;
+	
+	// Unity organization to list projects from
+	FString ServerUrl;
+
+	TArray<FString> ProjectNames;
+};
+
+
 /** Called when first activated on a project, and then at project load time.
  *  Look for the root directory of the Plastic workspace (where the ".plastic/" subdirectory is located). */
 class FPlasticConnectWorker final : public IPlasticSourceControlWorker
@@ -676,6 +694,20 @@ public:
 		: IPlasticSourceControlWorker(InSourceControlProvider)
 	{}
 	virtual ~FPlasticGetChangesetFilesWorker() = default;
+	// IPlasticSourceControlWorker interface
+	virtual FName GetName() const override;
+	virtual bool Execute(class FPlasticSourceControlCommand& InCommand) override;
+	virtual bool UpdateStates() override;
+};
+
+/** List Projects in Unity Organization. */
+class FPlasticGetProjectsWorker final : public IPlasticSourceControlWorker
+{
+public:
+	explicit FPlasticGetProjectsWorker(FPlasticSourceControlProvider& InSourceControlProvider)
+		: IPlasticSourceControlWorker(InSourceControlProvider)
+	{}
+	virtual ~FPlasticGetProjectsWorker() = default;
 	// IPlasticSourceControlWorker interface
 	virtual FName GetName() const override;
 	virtual bool Execute(class FPlasticSourceControlCommand& InCommand) override;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
@@ -314,7 +314,7 @@ public:
 	virtual FName GetName() const override;
 
 	virtual FText GetInProgressString() const override;
-	
+
 	// Unity organization to list projects from
 	FString ServerUrl;
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlOperations.h
@@ -104,9 +104,9 @@ public:
 
 	virtual FText GetInProgressString() const override;
 
-	FString WorkspaceName;
-	FString RepositoryName;
 	FString ServerUrl;
+	FString RepositoryName;
+	FString WorkspaceName;
 	bool bPartialWorkspace = false;
 };
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.cpp
@@ -56,6 +56,32 @@ TMap<FString, FString> ParseProfileInfo(TArray<FString>& InResults)
 }
 
 /**
+ * Parse the output of the command cm repository list --type=project"
+ *
+ * Example:
+My Project@SRombautsU@unity
+unreal-plugin@SRombautsU@unity
+*/
+TArray<FString> ParseRepository(TArray<FString>& InResults)
+{
+	TArray<FString> Repositories;
+
+	Repositories.Reserve(InResults.Num());
+
+	for (FString& Result : InResults)
+	{
+		int32 SeparatorIndex;
+		if (Result.FindChar(TEXT('@'), SeparatorIndex))
+		{
+			Result.LeftInline(SeparatorIndex);
+		}
+		Repositories.Add(MoveTemp(Result));
+	}
+
+	return Repositories;
+}
+
+/**
  * Parse  workspace information, in the form "Branch /main@UE5PlasticPluginDev@localhost:8087"
  *                                        or "Branch /main@UE5PlasticPluginDev@test@cloud" (when connected to the cloud)
  *                                        or "Branch /main@rep:UE5OpenWorldPerfTest@repserver:test@cloud"

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.cpp
@@ -29,30 +29,30 @@ namespace PlasticSourceControlParsers
 
 
 /**
- * Parse the output of the "cm profile list --format="{server};{user}" command
+ * Parse the output of the command cm profile list --format="{server};{user}"
  *
  * Example:
 localhost:8087|sebastien.rombauts
 local|sebastien.rombauts@unity3d.com
 SRombautsU@cloud|sebastien.rombauts@unity3d.com
 */
-bool ParseProfileInfo(TArray<FString>& InResults, const FString& InServerUrl, FString& OutUserName)
+TMap<FString, FString> ParseProfileInfo(TArray<FString>& InResults)
 {
+	TMap<FString, FString> Profiles;
+
+	Profiles.Reserve(InResults.Num());
+
 	for (const FString& Result : InResults)
 	{
 		TArray<FString> ProfileInfos;
 		Result.ParseIntoArray(ProfileInfos, FILE_STATUS_SEPARATOR, false); // Don't cull empty values
 		if (ProfileInfos.Num() == 2)
 		{
-			if (ProfileInfos[0] == InServerUrl)
-			{
-				OutUserName = ProfileInfos[1];
-				return true;
-			}
+			Profiles.Add({ MoveTemp(ProfileInfos[0]), MoveTemp(ProfileInfos[1]) });
 		}
 	}
 
-	return false;
+	return Profiles;
 }
 
 /**

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.h
@@ -53,7 +53,7 @@ struct FRemoveRedundantErrors
 	FString Filter;
 };
 
-bool ParseProfileInfo(TArray<FString>& InResults, const FString& InServerUrl, FString& OutUserName);
+TMap<FString, FString> ParseProfileInfo(TArray<FString>& InResults);
 
 bool ParseWorkspaceInfo(TArray<FString>& InResults, FString& OutWorkspaceSelector, FString& OutBranchName, FString& OutRepositoryName, FString& OutServerUrl);
 

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlParsers.h
@@ -55,6 +55,8 @@ struct FRemoveRedundantErrors
 
 TMap<FString, FString> ParseProfileInfo(TArray<FString>& InResults);
 
+TArray<FString> ParseRepository(TArray<FString>& InResults);
+
 bool ParseWorkspaceInfo(TArray<FString>& InResults, FString& OutWorkspaceSelector, FString& OutBranchName, FString& OutRepositoryName, FString& OutServerUrl);
 
 bool GetChangesetFromWorkspaceStatus(const TArray<FString>& InResults, int32& OutChangeset);

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
@@ -139,11 +139,14 @@ void FPlasticSourceControlProvider::CheckPlasticAvailability()
 		// Register Console Commands
 		PlasticSourceControlConsole.Register();
 
+		// List configured profiles (known servers and their associated user name)
+		Profiles = PlasticSourceControlUtils::GetProfiles();
+
 		if (bWorkspaceFound)
 		{
 			TArray<FString> ErrorMessages;
 			PlasticSourceControlUtils::GetWorkspaceInfo(WorkspaceSelector, BranchName, RepositoryName, ServerUrl, ErrorMessages);
-			UserName = PlasticSourceControlUtils::GetProfileUserName(ServerUrl);
+			UserName = PlasticSourceControlUtils::GetProfileUserName(Profiles, ServerUrl);
 		}
 		else
 		{
@@ -151,10 +154,6 @@ void FPlasticSourceControlProvider::CheckPlasticAvailability()
 			FFormatNamedArguments Args;
 			Args.Add(TEXT("WorkspacePath"), FText::FromString(PathToWorkspaceRoot));
 			FMessageLog("SourceControl").Info(FText::Format(LOCTEXT("NotInAWorkspace", "{WorkspacePath} is not in a workspace."), Args));
-
-			// Get default server and user name (from the global client config)
-			ServerUrl = PlasticSourceControlUtils::GetConfigDefaultRepServer();
-			UserName = PlasticSourceControlUtils::GetDefaultUserName();
 		}
 	}
 }

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
@@ -446,9 +446,9 @@ void FPlasticSourceControlProvider::UnregisterSourceControlStateChanged_Handle(F
 	ECommandResult::Type FPlasticSourceControlProvider::Execute(const FSourceControlOperationRef& InOperation, const TArray<FString>& InFiles,	EConcurrency::Type InConcurrency, const FSourceControlOperationComplete& InOperationCompleteDelegate)
 #endif
 {
-	if (!bWorkspaceFound && !(InOperation->GetName() == "Connect") && !(InOperation->GetName() == "MakeWorkspace"))
+	if (!bWorkspaceFound && !(InOperation->GetName() == "Connect") && !(InOperation->GetName() == "GetProjects") && !(InOperation->GetName() == "MakeWorkspace"))
 	{
-		UE_LOG(LogSourceControl, Warning, TEXT("'%s': only Connect operation allowed without a workspace"), *InOperation->GetName().ToString());
+		UE_LOG(LogSourceControl, Warning, TEXT("'%s': only Connect, GetProjects and MakeWorkspace operations allowed without a workspace"), *InOperation->GetName().ToString());
 		InOperationCompleteDelegate.ExecuteIfBound(InOperation, ECommandResult::Failed);
 		return ECommandResult::Failed;
 	}

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.cpp
@@ -313,6 +313,12 @@ const FName& FPlasticSourceControlProvider::GetName(void) const
 	return ProviderName;
 }
 
+void FPlasticSourceControlProvider::UpdateServerUrl(const FString& InServerUrl)
+{
+	ServerUrl = InServerUrl;
+	UserName = PlasticSourceControlUtils::GetProfileUserName(Profiles, InServerUrl);
+}
+
 FString FPlasticSourceControlProvider::GetCloudOrganization() const
 {
 	const int32 CloudIndex = ServerUrl.Find(TEXT("@cloud"));

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.h
@@ -97,6 +97,12 @@ public:
 		return PathToWorkspaceRoot;
 	}
 
+	/** List of configured profiles (known servers and their associated user name). */
+	inline const TMap<FString, FString>& GetProfiles() const
+	{
+		return Profiles;
+	}
+
 	/** Get the Plastic current user */
 	inline const FString& GetUserName() const
 	{
@@ -256,6 +262,9 @@ private:
 
 	/** Version of the Unity Version Control plugin */
 	FString PluginVersion;
+
+	/** List of configured profiles (servers and their corresponding user name). */
+	TMap<FString, FString> Profiles;
 
 	/** Path to the root of the Plastic workspace: can be the GameDir itself, or any parent directory (found by the "Connect" operation) */
 	FString PathToWorkspaceRoot;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlProvider.h
@@ -127,6 +127,8 @@ public:
 		return ServerUrl;
 	}
 
+	void UpdateServerUrl(const FString& InServerUrl);
+
 	/** Get the Name of the current branch */
 	inline const FString& GetBranchName() const
 	{

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -256,20 +256,6 @@ FString GetConfigDefaultRepServer()
 	return ServerUrl;
 }
 
-FString GetDefaultUserName()
-{
-	FString UserName;
-	TArray<FString> Results;
-	TArray<FString> ErrorMessages;
-	const bool bResult = RunCommand(TEXT("whoami"), TArray<FString>(), TArray<FString>(), Results, ErrorMessages);
-	if (bResult && Results.Num() > 0)
-	{
-		UserName = MoveTemp(Results[0]);
-	}
-
-	return UserName;
-}
-
 TMap<FString, FString> GetProfiles()
 {
 	TArray<FString> Results;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -283,6 +283,23 @@ FString GetProfileUserName(const TMap<FString, FString>& InProfiles, const FStri
 	return FString();
 }
 
+bool RunGetProjects(const FString& InServerUrl, TArray<FString>& OutProjectNames, TArray<FString>& OutErrorMessages)
+{
+	TArray<FString> Results;
+	TArray<FString> Parameters;
+	Parameters.Add("list");
+	Parameters.Add(InServerUrl);
+	Parameters.Add(TEXT("--type=project"));
+	bool bResult = RunCommand(TEXT("repository"), Parameters, TArray<FString>(), Results, OutErrorMessages);
+	if (bResult)
+	{
+		OutProjectNames = PlasticSourceControlParsers::ParseRepository(Results);
+	}
+
+	return bResult;
+}
+
+
 bool GetWorkspaceName(const FString& InWorkspaceRoot, FString& OutWorkspaceName, TArray<FString>& OutErrorMessages)
 {
 	TArray<FString> Results;

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -270,9 +270,8 @@ FString GetDefaultUserName()
 	return UserName;
 }
 
-FString GetProfileUserName(const FString& InServerUrl)
+TMap<FString, FString> GetProfiles()
 {
-	FString UserName;
 	TArray<FString> Results;
 	TArray<FString> Parameters;
 	TArray<FString> ErrorMessages;
@@ -281,10 +280,21 @@ FString GetProfileUserName(const FString& InServerUrl)
 	bool bResult = RunCommand(TEXT("profile"), Parameters, TArray<FString>(), Results, ErrorMessages);
 	if (bResult)
 	{
-		bResult = PlasticSourceControlParsers::ParseProfileInfo(Results, InServerUrl, UserName);
+		return PlasticSourceControlParsers::ParseProfileInfo(Results);
 	}
 
-	return UserName;
+	return TMap<FString, FString>();
+}
+
+
+FString GetProfileUserName(const TMap<FString, FString>& InProfiles, const FString& InServerUrl)
+{
+	if (const FString* UserName = InProfiles.Find(InServerUrl))
+	{
+		return *UserName;
+	}
+
+	return FString();
 }
 
 bool GetWorkspaceName(const FString& InWorkspaceRoot, FString& OutWorkspaceName, TArray<FString>& OutErrorMessages)

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
@@ -123,12 +123,6 @@ bool GetConfigSetFilesAsReadOnly();
 FString GetConfigDefaultRepServer();
 
 /**
- * Get Unity Version Control user for the default server
- * @returns	Name of the Unity Version Control user configured globally
- */
-FString GetDefaultUserName();
-
-/**
  * Get the list of configured profiles (known servers and their associated user name)
  * @returns	List of configured profiles (known servers and their associated user name)
  */

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
@@ -129,11 +129,18 @@ FString GetConfigDefaultRepServer();
 FString GetDefaultUserName();
 
 /**
- * Get Unity Version Control user for the specified server
+ * Get the list of configured profiles (known servers and their associated user name)
+ * @returns	List of configured profiles (known servers and their associated user name)
+ */
+TMap<FString, FString> GetProfiles();
+
+/**
+ * Get the configured user for the specified server
+ * @param	InProfiles		List of configured profiles
  * @param	InServerUrl		Name of the specified server
  * @returns	Name of the Unity Version Control user for the specified server
  */
-FString GetProfileUserName(const FString& InServerUrl);
+FString GetProfileUserName(const TMap<FString, FString>& InProfiles, const FString& InServerUrl);
 
 /**
  * Get workspace name

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.h
@@ -137,6 +137,14 @@ TMap<FString, FString> GetProfiles();
 FString GetProfileUserName(const TMap<FString, FString>& InProfiles, const FString& InServerUrl);
 
 /**
+ * Get the list of Projects for the specified Unity Organization
+ * @param	InServerUrl		    Name of the specified Unity Organization
+ * @returns	OutProjectNames     List of Projects for the specified Unity Organization
+ * @param	OutErrorMessages	Any errors (from StdErr) as an array per-line
+*/
+bool RunGetProjects(const FString& InServerUrl, TArray<FString>& OutProjectNames, TArray<FString>& OutErrorMessages);
+
+/**
  * Get workspace name
  * @param	InWorkspaceRoot		The workspace from where to run the command - typically the Project path
  * @param	OutWorkspaceName	Name of the current workspace

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlVersions.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlVersions.h
@@ -42,6 +42,10 @@ namespace PlasticSourceControlVersions
 	// https://plasticscm.com/download/releasenotes/11.0.16.7726 (2023/01/19)
 	static const FSoftwareVersion MergeXml(TEXT("11.0.16.7726"));
 
+	// 11.0.16.8044: Jun 08 2023! use cm shell "--enablestderr"
+	// https://plasticscm.com/download/releasenotes/11.0.16.8044 (2023/06/08)
+	static const FSoftwareVersion ShellStderr(TEXT("11.0.16.8044"));
+
 	// 11.0.16.8101 Introducing Smart Locks
 	// https://plasticscm.com/download/releasenotes/11.0.16.8101 (2023/07/06)
 	// 11.0.16.8133 add support for non-localized --datetimeformat

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlWorkspaceCreation.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlWorkspaceCreation.cpp
@@ -26,9 +26,16 @@ void FPlasticSourceControlWorkspaceCreation::MakeWorkspace(const FParameters& In
 void FPlasticSourceControlWorkspaceCreation::LaunchMakeWorkspaceOperation()
 {
 	TSharedRef<FPlasticMakeWorkspace, ESPMode::ThreadSafe> MakeWorkspaceOperation = ISourceControlOperation::Create<FPlasticMakeWorkspace>();
-	MakeWorkspaceOperation->WorkspaceName = WorkspaceParams.WorkspaceName.ToString();
-	MakeWorkspaceOperation->RepositoryName = WorkspaceParams.RepositoryName.ToString();
 	MakeWorkspaceOperation->ServerUrl = WorkspaceParams.ServerUrl.ToString();
+	if (!WorkspaceParams.ProjectName.IsEmpty())
+	{
+		MakeWorkspaceOperation->RepositoryName = FString::Printf(TEXT("%s/%s"), *WorkspaceParams.ProjectName.ToString(), *WorkspaceParams.RepositoryName.ToString());
+	}
+	else
+	{
+		MakeWorkspaceOperation->RepositoryName = WorkspaceParams.RepositoryName.ToString();
+	}
+	MakeWorkspaceOperation->WorkspaceName = WorkspaceParams.WorkspaceName.ToString();
 	MakeWorkspaceOperation->bPartialWorkspace = WorkspaceParams.bCreatePartialWorkspace;
 
 	FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlWorkspaceCreation.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlWorkspaceCreation.h
@@ -14,9 +14,10 @@ class FPlasticSourceControlWorkspaceCreation
 public:
 	struct FParameters
 	{
-		FText WorkspaceName;
-		FText RepositoryName;
 		FText ServerUrl;
+		FText ProjectName;
+		FText RepositoryName;
+		FText WorkspaceName;
 		bool bCreatePartialWorkspace = false;
 		bool bAutoInitialCommit = true;
 		FText InitialCommitMessage;

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlLocksWidget.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlLocksWidget.cpp
@@ -28,7 +28,6 @@
 #include "EditorStyleSet.h"
 #endif
 #include "Widgets/Images/SImage.h"
-#include "Widgets/Input/SComboButton.h"
 #include "Widgets/Input/SSearchBox.h"
 #include "Widgets/Layout/SSpacer.h"
 #include "Widgets/Text/STextBlock.h"

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.cpp
@@ -780,12 +780,23 @@ void SPlasticSourceControlSettings::OnGetProjectsOperationComplete(const FSource
 
 		UE_LOG(LogSourceControl, Verbose, TEXT("OnGetProjectsOperationComplete: %d projects in %s"), GetProjectsOperation->ProjectNames.Num(), *GetProjectsOperation->ServerUrl);
 
+		// Sort project alphanumerically
+		GetProjectsOperation->ProjectNames.Sort();
 		ProjectNames.Reserve(GetProjectsOperation->ProjectNames.Num());
 		for (FString& Project : GetProjectsOperation->ProjectNames)
 		{
 			ProjectNames.Add(FText::FromString(Project));
 		}
-		WorkspaceParams.ProjectName = ProjectNames[0];
+		// Try to find an existing Unity project with the same name as the Unreal project (that is, the repository name)
+		int32 Index;
+		if (GetProjectsOperation->ProjectNames.Find(WorkspaceParams.RepositoryName.ToString(), Index))
+		{
+			WorkspaceParams.ProjectName = ProjectNames[Index];
+		}
+		else
+		{
+			WorkspaceParams.ProjectName = ProjectNames[0];
+		}
 	}
 }
 

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.cpp
@@ -14,10 +14,12 @@
 #include "Styling/SlateTypes.h"
 #include "Widgets/Input/SButton.h"
 #include "Widgets/Input/SCheckBox.h"
+#include "Widgets/Input/SComboButton.h"
 #include "Widgets/Input/SEditableTextBox.h"
 #include "Widgets/Input/SHyperlink.h"
 #include "Widgets/Input/SMultiLineEditableTextBox.h"
 #include "Widgets/Layout/SBorder.h"
+#include "Widgets/Layout/SExpandableArea.h"
 #include "Widgets/Layout/SSeparator.h"
 #include "Widgets/Text/STextBlock.h"
 #include "Widgets/SBoxPanel.h"
@@ -29,6 +31,11 @@
 #endif
 
 #define LOCTEXT_NAMESPACE "SPlasticSourceControlSettings"
+
+bool IsUnityOrganization(const FString& InServerUrl)
+{
+	return InServerUrl.EndsWith(TEXT("@unity"));
+}
 
 void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 {
@@ -42,7 +49,29 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 	WorkspaceParams.bAutoInitialCommit = true;
 
 	WorkspaceParams.InitialCommitMessage = LOCTEXT("InitialCommitMessage", "Initial checkin");
-	WorkspaceParams.ServerUrl = FText::FromString(FPlasticSourceControlModule::Get().GetProvider().GetServerUrl());
+
+	const FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
+
+	const TMap<FString, FString>& Profiles = Provider.GetProfiles();
+	for (const auto& Profile : Profiles)
+	{
+		ServerNames.Add(FText::FromString(Profile.Key));
+	}
+
+	// If no workspace found, offer to create a new one on the selected server
+	if (Provider.IsPlasticAvailable() && !Provider.IsWorkspaceFound())
+	{
+		// Use the configured list of profiles from the provider so we can list both servers & associated user name
+		// Note: this doesn't need any of these to be editable, if they are missing the user needs to use the Desktop application to configure them.
+		if (!Provider.GetServerUrl().IsEmpty())
+		{
+			OnServerSelected(FText::FromString(Provider.GetServerUrl()));
+		}
+		else
+		{
+			OnServerSelected(FText::FromString(PlasticSourceControlUtils::GetConfigDefaultRepServer()));
+		}
+	}
 
 	if (FApp::HasProjectName())
 	{
@@ -59,6 +88,7 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 	[
 #endif
 		SNew(SVerticalBox)
+		// Path to the CLI
 		// Versions (Plugin & Unity Version Control) useful eg to help diagnose issues from screenshots
 		+SVerticalBox::Slot()
 		.AutoHeight()
@@ -69,13 +99,24 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 			.ToolTipText(LOCTEXT("PlasticVersions_Tooltip", "Unity Version Control (formerly Plastic SCM) and Plugin versions"))
 			+SHorizontalBox::Slot()
 			.FillWidth(1.0f)
+            .Padding(0.0f, 3.0f)
 			[
 				SNew(STextBlock)
 				.Text(LOCTEXT("PlasticVersions", "Unity Version Control"))
 				.Font(Font)
 			]
 			+SHorizontalBox::Slot()
-			.FillWidth(2.0f)
+			.FillWidth(0.5f)
+			[
+				SNew(SEditableTextBox)
+				.Text(this, &SPlasticSourceControlSettings::GetBinaryPathText)
+				.HintText(LOCTEXT("BinaryPathLabel", "Path to the Unity Version Control 'cm' executable"))
+				.OnTextCommitted(this, &SPlasticSourceControlSettings::OnBinaryPathTextCommited)
+				.Font(Font)
+			]
+			+SHorizontalBox::Slot()
+			.FillWidth(1.5f)
+            .Padding(4.0f, 3.0f)
 			[
 				SNew(STextBlock)
 				.Text(this, &SPlasticSourceControlSettings::GetVersions)
@@ -118,31 +159,6 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 				}))
 			]
 		]
-		// Path to the Unity Version Control binary
-		+SVerticalBox::Slot()
-		.AutoHeight()
-		.Padding(2.0f)
-		.VAlign(VAlign_Center)
-		[
-			SNew(SHorizontalBox)
-			.ToolTipText(LOCTEXT("BinaryPathLabel_Tooltip", "Path to the Unity Version Control Command Line tool 'cm' executable"))
-			+SHorizontalBox::Slot()
-			.FillWidth(1.0f)
-			[
-				SNew(STextBlock)
-				.Text(LOCTEXT("PathLabel", "Path to cm"))
-				.Font(Font)
-			]
-			+SHorizontalBox::Slot()
-			.FillWidth(2.0f)
-			[
-				SNew(SEditableTextBox)
-				.Text(this, &SPlasticSourceControlSettings::GetBinaryPathText)
-				.HintText(LOCTEXT("BinaryPathLabel", "Path to the Unity Version Control 'cm' executable"))
-				.OnTextCommitted(this, &SPlasticSourceControlSettings::OnBinaryPathTextCommited)
-				.Font(Font)
-			]
-		]
 		// Root of the workspace
 		+SVerticalBox::Slot()
 		.AutoHeight()
@@ -166,19 +182,63 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 				.Font(Font)
 			]
 		]
-		// User Name
+		// No Workspace found - Separator and explanation text
 		+SVerticalBox::Slot()
 		.AutoHeight()
-		.Padding(2.0f)
+		.Padding(2.0f, 4.0f)
+		.VAlign(VAlign_Center)
+		[
+			SNew(SSeparator)
+			.Visibility(this, &SPlasticSourceControlSettings::CanCreatePlasticWorkspace)
+		]
+		+SVerticalBox::Slot()
+		.AutoHeight()
+		.Padding(2.0f, 4.0f)
+		[
+			SNew(STextBlock)
+			.Visibility(this, &SPlasticSourceControlSettings::CanCreatePlasticWorkspace)
+			.ToolTipText(LOCTEXT("WorkspaceNotFound_Tooltip", "No Workspace found at the level or above the current Unreal project. Use the form to create a new one."))
+			.Text(LOCTEXT("WorkspaceNotFound", "Create a Workspace for your Unreal project:"))
+			.Font(Font)
+		]
+		// Repository specification if Workspace found
+		+ SVerticalBox::Slot()
+		.AutoHeight()
+		.Padding(2.0f, 4.0f)
 		.VAlign(VAlign_Center)
 		[
 			SNew(SHorizontalBox)
-			.ToolTipText(LOCTEXT("PlasticUserName_Tooltip", "User name configured for the Unity Version Control workspace"))
+			.Visibility(this, &SPlasticSourceControlSettings::IsWorkspaceFound)
+			.ToolTipText(this, &SPlasticSourceControlSettings::GetRepositorySpec)
+			+ SHorizontalBox::Slot()
+			.FillWidth(1.0f)
+			[
+				SNew(STextBlock)
+					.Text(LOCTEXT("RepositorySpecification", "Repository"))
+					.Font(Font)
+			]
+			+ SHorizontalBox::Slot()
+			.FillWidth(2.0f)
+			[
+				SNew(STextBlock)
+					.Text(this, &SPlasticSourceControlSettings::GetRepositorySpec)
+					.Font(Font)
+			]
+		]
+
+		// User Name configured for the selected server
+		+SVerticalBox::Slot()
+		.AutoHeight()
+		.Padding(2.0f, 4.0f)
+		.VAlign(VAlign_Center)
+		[
+			SNew(SHorizontalBox)
+			.ToolTipText(LOCTEXT("PlasticUserName_Tooltip", "User name configured for the selected Unity Version Control server"))
 			+SHorizontalBox::Slot()
 			.FillWidth(1.0f)
 			[
 				SNew(STextBlock)
-				.Text(LOCTEXT("PlasticUserName", "User Name"))
+				.Text(LOCTEXT("PlasticUserName", "User name"))
 				.Font(Font)
 			]
 			+SHorizontalBox::Slot()
@@ -189,26 +249,107 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 				.Font(Font)
 			]
 		]
-		// Separator
+
+		// Organization Name or Server URL address:port Dropdown
 		+SVerticalBox::Slot()
 		.AutoHeight()
 		.Padding(2.0f)
 		.VAlign(VAlign_Center)
 		[
-			SNew(SSeparator)
+			SNew(SHorizontalBox)
+			.Visibility(this, &SPlasticSourceControlSettings::CanSelectServer)
+			.ToolTipText(LOCTEXT("ServerUrl_Tooltip", "Enter the cloud organization (eg. YourOrganization@cloud, YourOrganization@unity, local) or the Server URL in the form address:port or ssl://ip:port (eg localhost:8087)"))
+			+SHorizontalBox::Slot()
+			.FillWidth(1.0f)
+            .Padding(0.0f, 4.0f)
+			[
+				SNew(STextBlock)
+				.Text(LOCTEXT("ServerUrl", "Organization or server"))
+				.Font(Font)
+			]
+			+SHorizontalBox::Slot()
+			.FillWidth(2.0f)
+			.Padding(2.0f, 0.0f, 0.0f, 0.0f)
+			[
+				SNew(SComboButton)
+				.OnGetMenuContent(this, &SPlasticSourceControlSettings::BuildServerDropDownMenu)
+				.IsEnabled_Lambda([this] { return !bGetProjectsInProgress; })
+				.ButtonContent()
+				[
+					SNew(STextBlock)
+					.Text(this, &SPlasticSourceControlSettings::GetServerUrl)
+					.Font(Font)
+				]
+			]
 		]
-		// Explanation text
+		// No Known Server configured - Error message and explanation
 		+SVerticalBox::Slot()
 		.AutoHeight()
-		.Padding(2.0f, 5.0f)
+		.Padding(2.0f)
 		[
 			SNew(STextBlock)
-			.Visibility(this, &SPlasticSourceControlSettings::CanCreatePlasticWorkspace)
-			.ToolTipText(LOCTEXT("WorkspaceNotFound_Tooltip", "No Workspace found at the level or above the current Project. Use the form to create a new one."))
-			.Text(LOCTEXT("WorkspaceNotFound", "Current Project is not in a Unity Version Control Workspace. Create a new one:"))
+			.Visibility(this, &SPlasticSourceControlSettings::NoServerToSelect)
+			.ToolTipText(LOCTEXT("NoKnownServer_Tooltip", "You don't have any server configured.\nYou need to launch the Desktop application and make sure it is correctly configured with your credentials."))
+			.Text(LOCTEXT("NoKnownServer", "You don't have any server configured."))
+			.Font(Font)
+			.ColorAndOpacity(FLinearColor::Red)
+		]
+
+		// Organization Project Dropdown
+		+SVerticalBox::Slot()
+		.AutoHeight()
+		.Padding(2.0f)
+		.VAlign(VAlign_Center)
+		[
+			SNew(SHorizontalBox)
+			.Visibility(this, &SPlasticSourceControlSettings::CanSelectProject)
+            .ToolTipText(LOCTEXT("ProjectName_Tooltip", "Select the name of the Project to use"))
+			+SHorizontalBox::Slot()
+			.FillWidth(1.0f)
+            .Padding(0.0f, 4.0f)
+			[
+				SNew(STextBlock)
+				.Text(LOCTEXT("ProjectName", "Organization's project"))
+				.Font(Font)
+			]
+			+SHorizontalBox::Slot()
+			.FillWidth(2.0f)
+			.Padding(2.0f, 0.0f, 0.0f, 0.0f)
+			[
+				SNew(SComboButton)
+				.OnGetMenuContent(this, &SPlasticSourceControlSettings::BuildProjectDropDownMenu)
+				.ButtonContent()
+				[
+					SNew(STextBlock)
+					.Text(this, &SPlasticSourceControlSettings::GetProjectName)
+					.Font(Font)
+				]
+			]
+		]
+		// No Project Explanation text
+		+SVerticalBox::Slot()
+		.AutoHeight()
+		.Padding(2.0f)
+		[
+			SNew(STextBlock)
+			.Visibility_Lambda([this] { return bGetProjectsInProgress ? EVisibility::Visible : EVisibility::Collapsed; })
+			.Text(LOCTEXT("GetProjectsInProgress", "Getting the list of projects in this Unity Organization..."))
 			.Font(Font)
 		]
-		// Workspace and Repository Name
+		// No Project Explanation text
+		+SVerticalBox::Slot()
+		.AutoHeight()
+		.Padding(2.0f)
+		[
+			SNew(STextBlock)
+			.Visibility(this, &SPlasticSourceControlSettings::NoProjectToSelect)
+			.ToolTipText(LOCTEXT("NoProject_Tooltip", "You don't have access to any Project in this Unity organization.\nYou need to use the Unity Dashboard to make sure you have access to a project in the selected Unity organization."))
+			.Text(LOCTEXT("NoProject", "You don't have access to any Project in this Unity organization."))
+			.Font(Font)
+			.ColorAndOpacity(FLinearColor::Red)
+		]
+
+		// Repository Name
 		+SVerticalBox::Slot()
 		.AutoHeight()
 		.Padding(2.0f)
@@ -216,38 +357,27 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 		[
 			SNew(SHorizontalBox)
 			.Visibility(this, &SPlasticSourceControlSettings::CanCreatePlasticWorkspace)
+            .ToolTipText(LOCTEXT("RepositoryName_Tooltip", "Enter the Name of the Repository to use or create"))
 			+SHorizontalBox::Slot()
 			.FillWidth(1.0f)
+            .Padding(0.0f, 3.0f)
 			[
 				SNew(STextBlock)
-				.Text(LOCTEXT("WorkspaceRepositoryName", "Workspace & Repository"))
-				.ToolTipText(LOCTEXT("WorkspaceRepositoryName_Tooltip", "Enter the Name of the new Workspace and Repository to create or use"))
+				.Text(LOCTEXT("RepositoryName", "Repository name"))
 				.Font(Font)
 			]
 			+SHorizontalBox::Slot()
-			.FillWidth(1.0f)
-			.Padding(2.0f, 0.0f, 0.0f, 0.0f)
-			[
-				SNew(SEditableTextBox)
-				.Text(this, &SPlasticSourceControlSettings::GetWorkspaceName)
-				.ToolTipText(LOCTEXT("WorkspaceName_Tooltip", "Enter the Name of the new Workspace to create"))
-				.HintText(LOCTEXT("WorkspaceName_Hint", "Name of the Workspace to create"))
-				.OnTextCommitted(this, &SPlasticSourceControlSettings::OnWorkspaceNameCommited)
-				.Font(Font)
-			]
-			+SHorizontalBox::Slot()
-			.FillWidth(1.0f)
+			.FillWidth(2.0f)
 			.Padding(2.0f, 0.0f, 0.0f, 0.0f)
 			[
 				SNew(SEditableTextBox)
 				.Text(this, &SPlasticSourceControlSettings::GetRepositoryName)
-				.ToolTipText(LOCTEXT("RepositoryName_Tooltip", "Enter the Name of the Repository to use or create"))
 				.HintText(LOCTEXT("RepositoryName_Hint", "Name of the Repository to use or create"))
 				.OnTextCommitted(this, &SPlasticSourceControlSettings::OnRepositoryNameCommited)
 				.Font(Font)
 			]
 		]
-		// Server URL address:port
+		// Workspace Name
 		+SVerticalBox::Slot()
 		.AutoHeight()
 		.Padding(2.0f)
@@ -255,25 +385,27 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 		[
 			SNew(SHorizontalBox)
 			.Visibility(this, &SPlasticSourceControlSettings::CanCreatePlasticWorkspace)
-			.ToolTipText(LOCTEXT("ServerUrl_Tooltip", "Enter the Server URL in the form address:port (eg. YourOrganization@cloud, local, or something like ip:port, eg localhost:8087)"))
+            .ToolTipText(LOCTEXT("WorkspaceName_Tooltip", "Enter the Name of the new Workspace to create"))
 			+SHorizontalBox::Slot()
 			.FillWidth(1.0f)
+            .Padding(0.0f, 3.0f)
 			[
 				SNew(STextBlock)
-				.Text(LOCTEXT("ServerUrl", "Server URL address:port"))
+				.Text(LOCTEXT("WorkspaceName", "Workspace name"))
 				.Font(Font)
 			]
 			+SHorizontalBox::Slot()
 			.FillWidth(2.0f)
+			.Padding(2.0f, 0.0f, 0.0f, 0.0f)
 			[
 				SNew(SEditableTextBox)
-				.Text(this, &SPlasticSourceControlSettings::GetServerUrl)
-				.HintText(LOCTEXT("EnterServerUrl", "Enter the Server URL"))
-				.OnTextCommitted(this, &SPlasticSourceControlSettings::OnServerUrlCommited)
+				.Text(this, &SPlasticSourceControlSettings::GetWorkspaceName)
+				.HintText(LOCTEXT("WorkspaceName_Hint", "Name of the Workspace to create"))
+				.OnTextCommitted(this, &SPlasticSourceControlSettings::OnWorkspaceNameCommited)
 				.Font(Font)
 			]
 		]
-		// Option to create a Partial/Gluon Workspace designed
+		// Option to create a Partial/Gluon Workspace designed to only sync selected files and allow to check-in when the workspace is not up to date.
 		+SVerticalBox::Slot()
 		.AutoHeight()
 		.Padding(2.0f)
@@ -281,7 +413,7 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 		[
 			SNew(SCheckBox)
 			.Visibility(this, &SPlasticSourceControlSettings::CanCreatePlasticWorkspace)
-			.ToolTipText(LOCTEXT("CreatePartialWorkspace_Tooltip", "Create the new workspace in Gluon/partial mode, designed for artists."))
+			.ToolTipText(LOCTEXT("CreatePartialWorkspace_Tooltip", "Create the new workspace in Gluon/partial mode, designed for artists, instead of a Full/regular workspace for developpers."))
 			.IsChecked(WorkspaceParams.bCreatePartialWorkspace)
 			.OnCheckStateChanged(this, &SPlasticSourceControlSettings::OnCheckedCreatePartialWorkspace)
 			[
@@ -308,7 +440,7 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 				.Font(Font)
 			]
 		]
-		// Option to Make the initial Unity Version Control checkin
+		// Option to Make the initial checkin of the whole project
 		+SVerticalBox::Slot()
 		.AutoHeight()
 		.Padding(2.0f)
@@ -316,7 +448,7 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 		[
 			SNew(SHorizontalBox)
 			.Visibility(this, &SPlasticSourceControlSettings::CanCreatePlasticWorkspace)
-			.ToolTipText(LOCTEXT("InitialCommit_Tooltip", "Make the initial Unity Version Control checkin"))
+			.ToolTipText(LOCTEXT("InitialCommit_Tooltip", "Make the initial checkin of the whole project"))
 			+SHorizontalBox::Slot()
 			.FillWidth(0.7f)
 			[
@@ -331,7 +463,6 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 			]
 			+SHorizontalBox::Slot()
 			.FillWidth(1.4f)
-			.Padding(2.0f)
 			[
 				SNew(SMultiLineEditableTextBox)
 				.Text(this, &SPlasticSourceControlSettings::GetInitialCommitMessage)
@@ -340,112 +471,138 @@ void SPlasticSourceControlSettings::Construct(const FArguments& InArgs)
 				.Font(Font)
 			]
 		]
-		// Option to run an Update Status operation at Editor Startup
+
+		// Advanced runtime Settings expandable area
 		+SVerticalBox::Slot()
+		.VAlign(VAlign_Top)
 		.AutoHeight()
-		.Padding(2.0f)
-		.VAlign(VAlign_Center)
+		.Padding(0.0f)
 		[
-			SNew(SCheckBox)
-			.IsChecked(SPlasticSourceControlSettings::IsUpdateStatusAtStartupChecked())
-			.OnCheckStateChanged(this, &SPlasticSourceControlSettings::OnCheckedUpdateStatusAtStartup)
-			.ToolTipText(LOCTEXT("UpdateStatusAtStartup_Tooltip", "Run an asynchronous Update Status at Editor startup (can be slow)."))
+			SNew(SExpandableArea)
+			.BorderImage(FAppStyle::Get().GetBrush("NoBorder"))
+			.InitiallyCollapsed(true)
+			.HeaderContent()
 			[
 				SNew(STextBlock)
-				.Text(LOCTEXT("UpdateStatusAtStartup", "Update workspace Status at Editor startup"))
-				.Font(Font)
+				.Text(LOCTEXT("AdvancedRuntimeSettings", "Advanced runtime Settings"))
 			]
-		]
-		// Option to call History as part of Update Status operation to check for potential recent changes in other branches
-		+SVerticalBox::Slot()
-		.AutoHeight()
-		.Padding(2.0f)
-		.VAlign(VAlign_Center)
-		[
-			SNew(SCheckBox)
-			.ToolTipText(LOCTEXT("UpdateStatusOtherBranches_Tooltip", "Enable Update status to detect more recent changes on other branches in order to display warnings (can be slow)."))
-			.IsChecked(SPlasticSourceControlSettings::IsUpdateStatusOtherBranchesChecked())
-			.OnCheckStateChanged(this, &SPlasticSourceControlSettings::OnCheckedUpdateStatusOtherBranches)
+			.BodyContent()
 			[
-				SNew(STextBlock)
-				.Text(LOCTEXT("UpdateStatusOtherBranches", "Update Status also checks history to detect changes on other branches."))
-				.Font(Font)
-			]
-		]
-		// Option for the View Changes (Changelists) window to also show locally Changed and Private files
-		+SVerticalBox::Slot()
-		.AutoHeight()
-		.Padding(2.0f)
-		.VAlign(VAlign_Center)
-		[
-			SNew(SCheckBox)
-			.ToolTipText(LOCTEXT("ViewLocalChanges_Tooltip", "Enable the \"View Changes\" window to search for and show locally Changed and Private files (can be slow)."))
-			.IsChecked(SPlasticSourceControlSettings::IsViewLocalChangesChecked())
-			.OnCheckStateChanged(this, &SPlasticSourceControlSettings::OnCheckedViewLocalChanges)
-			[
-				SNew(STextBlock)
-				.Text(LOCTEXT("ViewLocalChanges", "Show local Changes in the \"View Changes\" window."))
-				.Font(Font)
-			]
-		]
-		// Option to enable Source Control Verbose logs
-		+SVerticalBox::Slot()
-		.AutoHeight()
-		.Padding(2.0f)
-		.VAlign(VAlign_Center)
-		[
-			SNew(SCheckBox)
-			.ToolTipText(LOCTEXT("EnableVerboseLogs_Tooltip", "Override LogSourceControl default verbosity level to Verbose (except if already set to VeryVerbose)."))
-			.IsChecked(SPlasticSourceControlSettings::IsEnableVerboseLogsChecked())
-			.OnCheckStateChanged(this, &SPlasticSourceControlSettings::OnCheckedEnableVerboseLogs)
-			[
-				SNew(STextBlock)
+				SNew(SBorder)
+				.BorderImage(FAppStyle::Get().GetBrush("NoBorder"))
+				.Padding(0)
+				[
+					SNew(SVerticalBox)
+					// Option to run an Update Status operation at Editor Startup
+					+SVerticalBox::Slot()
+					.AutoHeight()
+					.Padding(2.0f)
+					.VAlign(VAlign_Center)
+					[
+						SNew(SCheckBox)
+						.IsChecked(SPlasticSourceControlSettings::IsUpdateStatusAtStartupChecked())
+						.OnCheckStateChanged(this, &SPlasticSourceControlSettings::OnCheckedUpdateStatusAtStartup)
+						.ToolTipText(LOCTEXT("UpdateStatusAtStartup_Tooltip", "Run an asynchronous Update Status at Editor startup (can be slow)."))
+						[
+							SNew(STextBlock)
+							.Text(LOCTEXT("UpdateStatusAtStartup", "Update workspace Status at Editor startup"))
+							.Font(Font)
+						]
+					]
+					// Option to call History as part of Update Status operation to check for potential recent changes in other branches
+					+SVerticalBox::Slot()
+					.AutoHeight()
+					.Padding(2.0f)
+					.VAlign(VAlign_Center)
+					[
+						SNew(SCheckBox)
+						.ToolTipText(LOCTEXT("UpdateStatusOtherBranches_Tooltip", "Enable Update status to detect more recent changes on other branches in order to display warnings (can be slow)."))
+						.IsChecked(SPlasticSourceControlSettings::IsUpdateStatusOtherBranchesChecked())
+						.OnCheckStateChanged(this, &SPlasticSourceControlSettings::OnCheckedUpdateStatusOtherBranches)
+						[
+							SNew(STextBlock)
+							.Text(LOCTEXT("UpdateStatusOtherBranches", "Update Status also checks history to detect changes on other branches."))
+							.Font(Font)
+						]
+					]
+					// Option for the View Changes (Changelists) window to also show locally Changed and Private files
+					+SVerticalBox::Slot()
+					.AutoHeight()
+					.Padding(2.0f)
+					.VAlign(VAlign_Center)
+					[
+						SNew(SCheckBox)
+						.ToolTipText(LOCTEXT("ViewLocalChanges_Tooltip", "Enable the \"View Changes\" window to search for and show locally Changed and Private files (can be slow)."))
+						.IsChecked(SPlasticSourceControlSettings::IsViewLocalChangesChecked())
+						.OnCheckStateChanged(this, &SPlasticSourceControlSettings::OnCheckedViewLocalChanges)
+						[
+							SNew(STextBlock)
+							.Text(LOCTEXT("ViewLocalChanges", "Show local Changes in the \"View Changes\" window."))
+							.Font(Font)
+						]
+					]
+					// Option to enable Source Control Verbose logs
+					+SVerticalBox::Slot()
+					.AutoHeight()
+					.Padding(2.0f)
+					.VAlign(VAlign_Center)
+					[
+						SNew(SCheckBox)
+						.ToolTipText(LOCTEXT("EnableVerboseLogs_Tooltip", "Override LogSourceControl default verbosity level to Verbose (except if already set to VeryVerbose)."))
+						.IsChecked(SPlasticSourceControlSettings::IsEnableVerboseLogsChecked())
+						.OnCheckStateChanged(this, &SPlasticSourceControlSettings::OnCheckedEnableVerboseLogs)
+						[
+							SNew(STextBlock)
 #if ENGINE_MAJOR_VERSION == 5 && ENGINE_MINOR_VERSION >= 2
-				.Text(LOCTEXT("EnableVerboseLogs", "Enable Revision Control Verbose logs"))
+							.Text(LOCTEXT("EnableVerboseLogs", "Enable Revision Control Verbose logs"))
 #else
-				.Text(LOCTEXT("EnableVerboseLogs", "Enable Source Control Verbose logs"))
+							.Text(LOCTEXT("EnableVerboseLogs", "Enable Source Control Verbose logs"))
 #endif
-				.Font(Font)
+							.Font(Font)
+						]
+					]
+				]
 			]
 		]
-		// Button to create a new Workspace
-		+SVerticalBox::Slot()
-		.FillHeight(2.5f)
-		.Padding(4.0f)
-		.VAlign(VAlign_Center)
-		[
-			SNew(SHorizontalBox)
-			.Visibility(this, &SPlasticSourceControlSettings::CanCreatePlasticWorkspace)
-			+SHorizontalBox::Slot()
-			.FillWidth(1.0f)
-			[
-				SNew(SButton)
-				.IsEnabled(this, &SPlasticSourceControlSettings::IsReadyToCreatePlasticWorkspace)
-				.Text(LOCTEXT("PlasticInitWorkspace", "Create a new Unity Version Control workspace for the current project"))
-				.ToolTipText(LOCTEXT("PlasticInitWorkspace_Tooltip", "Create a new Unity Version Control repository and workspace and for the current project"))
-				.OnClicked(this, &SPlasticSourceControlSettings::OnClickedCreatePlasticWorkspace)
-				.HAlign(HAlign_Center)
-				.ContentPadding(6.0f)
-			]
-		]
-		// Button to add a 'ignore.conf' file on an existing Workspace
-		+SVerticalBox::Slot()
-		.FillHeight(2.0f)
-		.Padding(2.0f)
-		.VAlign(VAlign_Center)
-		[
-			SNew(SHorizontalBox)
-			.Visibility(this, &SPlasticSourceControlSettings::CanAddIgnoreFile)
-			+SHorizontalBox::Slot()
-			.FillWidth(1.0f)
-			[
-				SNew(SButton)
-				.Text(LOCTEXT("CreateIgnoreFile", "Add a ignore.conf file"))
-				.ToolTipText(LOCTEXT("CreateIgnoreFile_Tooltip", "Create and add a standard 'ignore.conf' file"))
-				.OnClicked(this, &SPlasticSourceControlSettings::OnClickedAddIgnoreFile)
-				.HAlign(HAlign_Center)
-			]
-		]
+
+        // Button to create a new Workspace
+        +SVerticalBox::Slot()
+        .FillHeight(2.5f)
+        .Padding(4.0f)
+        .VAlign(VAlign_Center)
+        [
+            SNew(SHorizontalBox)
+            .Visibility(this, &SPlasticSourceControlSettings::CanCreatePlasticWorkspace)
+            +SHorizontalBox::Slot()
+            .FillWidth(1.0f)
+            [
+                SNew(SButton)
+                .IsEnabled(this, &SPlasticSourceControlSettings::IsReadyToCreatePlasticWorkspace)
+                .Text(LOCTEXT("PlasticInitWorkspace", "Create a new Unity Version Control workspace for the current project"))
+                .ToolTipText(LOCTEXT("PlasticInitWorkspace_Tooltip", "Create a new Unity Version Control repository and workspace and for the current project"))
+                .OnClicked(this, &SPlasticSourceControlSettings::OnClickedCreatePlasticWorkspace)
+                .HAlign(HAlign_Center)
+                .ContentPadding(6.0f)
+            ]
+        ]
+        // Button to add a 'ignore.conf' file on an existing Workspace
+        +SVerticalBox::Slot()
+        .FillHeight(2.0f)
+        .Padding(2.0f)
+        .VAlign(VAlign_Center)
+        [
+            SNew(SHorizontalBox)
+            .Visibility(this, &SPlasticSourceControlSettings::CanAddIgnoreFile)
+            +SHorizontalBox::Slot()
+            .FillWidth(1.0f)
+            [
+                SNew(SButton)
+                .Text(LOCTEXT("CreateIgnoreFile", "Add a ignore.conf file"))
+                .ToolTipText(LOCTEXT("CreateIgnoreFile_Tooltip", "Create and add a standard 'ignore.conf' file"))
+                .OnClicked(this, &SPlasticSourceControlSettings::OnClickedAddIgnoreFile)
+                .HAlign(HAlign_Center)
+            ]
+        ]
 #if ENGINE_MAJOR_VERSION == 4
 	]
 #endif
@@ -495,6 +652,14 @@ FText SPlasticSourceControlSettings::GetUserName() const
 }
 
 
+EVisibility SPlasticSourceControlSettings::IsWorkspaceFound() const
+{
+	const FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
+	const bool bPlasticAvailable = Provider.IsPlasticAvailable();
+	const bool bPlasticWorkspaceFound = Provider.IsWorkspaceFound();
+	return (bPlasticAvailable && bPlasticWorkspaceFound) ? EVisibility::Visible : EVisibility::Collapsed;
+}
+
 EVisibility SPlasticSourceControlSettings::CanCreatePlasticWorkspace() const
 {
 	const FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
@@ -503,25 +668,146 @@ EVisibility SPlasticSourceControlSettings::CanCreatePlasticWorkspace() const
 	return (bPlasticAvailable && !bPlasticWorkspaceFound) ? EVisibility::Visible : EVisibility::Collapsed;
 }
 
+EVisibility SPlasticSourceControlSettings::CanSelectServer() const
+{
+	const FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
+	const bool bPlasticAvailable = Provider.IsPlasticAvailable();
+	const bool bPlasticWorkspaceFound = Provider.IsWorkspaceFound();
+	const bool bHasKnownServers = !ServerNames.IsEmpty();
+	return (bPlasticAvailable && !bPlasticWorkspaceFound && bHasKnownServers) ? EVisibility::Visible : EVisibility::Collapsed;
+}
+
+EVisibility SPlasticSourceControlSettings::NoServerToSelect() const
+{
+	const FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
+	const bool bPlasticAvailable = Provider.IsPlasticAvailable();
+	const bool bPlasticWorkspaceFound = Provider.IsWorkspaceFound();
+	const bool bHasKnownServers = !ServerNames.IsEmpty();
+	return (bPlasticAvailable && !bPlasticWorkspaceFound && !bHasKnownServers) ? EVisibility::Visible : EVisibility::Collapsed;
+}
+
+
+EVisibility SPlasticSourceControlSettings::CanSelectProject() const
+{
+	const FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
+	const bool bPlasticAvailable = Provider.IsPlasticAvailable();
+	const bool bPlasticWorkspaceFound = Provider.IsWorkspaceFound();
+	const bool bIsUnityOrganization = IsUnityOrganization(WorkspaceParams.ServerUrl.ToString());
+	const bool bHasProjects = !ProjectNames.IsEmpty();
+	return (bPlasticAvailable && !bPlasticWorkspaceFound && bIsUnityOrganization && bHasProjects) ? EVisibility::Visible : EVisibility::Collapsed;
+}
+
+EVisibility SPlasticSourceControlSettings::NoProjectToSelect() const
+{
+	const FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
+	const bool bPlasticAvailable = Provider.IsPlasticAvailable();
+	const bool bPlasticWorkspaceFound = Provider.IsWorkspaceFound();
+	const bool bIsUnityOrganization = IsUnityOrganization(WorkspaceParams.ServerUrl.ToString());
+	const bool bHasProjects = !ProjectNames.IsEmpty();
+	return (bPlasticAvailable && !bPlasticWorkspaceFound && bIsUnityOrganization && !bHasProjects && !bGetProjectsInProgress) ? EVisibility::Visible : EVisibility::Collapsed;
+}
+
 bool SPlasticSourceControlSettings::IsReadyToCreatePlasticWorkspace() const
 {
 	// Workspace Name cannot be left empty
 	const bool bWorkspaceNameOk = !WorkspaceParams.WorkspaceName.IsEmpty();
 	// RepositoryName and ServerUrl should also be filled
 	const bool bRepositoryNameOk = !WorkspaceParams.RepositoryName.IsEmpty() && !WorkspaceParams.ServerUrl.IsEmpty();
+	// And the Project is required if the server is a Unity Organization
+	const bool bProjectNameOk = !IsUnityOrganization(WorkspaceParams.ServerUrl.ToString()) || !WorkspaceParams.ProjectName.IsEmpty();
 	// If Initial Commit is requested, checkin message cannot be empty
 	const bool bInitialCommitOk = (!WorkspaceParams.bAutoInitialCommit || !WorkspaceParams.InitialCommitMessage.IsEmpty());
-	return bWorkspaceNameOk && bRepositoryNameOk && bInitialCommitOk;
+	return bWorkspaceNameOk && bRepositoryNameOk && bProjectNameOk && bInitialCommitOk;
 }
 
-
-void SPlasticSourceControlSettings::OnWorkspaceNameCommited(const FText& InText, ETextCommit::Type InCommitType)
+FText SPlasticSourceControlSettings::GetRepositorySpec() const
 {
-	WorkspaceParams.WorkspaceName = InText;
+	const FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
+	return FText::FromString(FString::Printf(TEXT("%s@%s"), *Provider.GetRepositoryName(), *Provider.GetServerUrl()));
 }
-FText SPlasticSourceControlSettings::GetWorkspaceName() const
+
+FText SPlasticSourceControlSettings::GetServerUrl() const
 {
-	return WorkspaceParams.WorkspaceName;
+	return WorkspaceParams.ServerUrl;
+}
+TSharedRef<SWidget> SPlasticSourceControlSettings::BuildServerDropDownMenu()
+{
+	FMenuBuilder MenuBuilder(true, NULL);
+
+	for (const FText& ServerName : ServerNames)
+	{
+		FUIAction MenuAction(FExecuteAction::CreateSP(this, &SPlasticSourceControlSettings::OnServerSelected, ServerName));
+		MenuBuilder.AddMenuEntry(ServerName, ServerName, FSlateIcon(), MenuAction);
+	}
+
+	return MenuBuilder.MakeWidget();
+}
+void SPlasticSourceControlSettings::OnServerSelected(const FText InServerName)
+{
+	if (WorkspaceParams.ServerUrl.EqualTo(InServerName))
+		return;
+
+	WorkspaceParams.ServerUrl = InServerName;
+	WorkspaceParams.ProjectName = FText::GetEmpty();
+
+	UE_LOG(LogSourceControl, Verbose, TEXT("OnServerSelected(%s)"), *WorkspaceParams.ServerUrl.ToString());
+
+	FPlasticSourceControlModule::Get().GetProvider().UpdateServerUrl(WorkspaceParams.ServerUrl.ToString());
+
+	// Get the Projects for the Unity Organization
+	if (IsUnityOrganization(WorkspaceParams.ServerUrl.ToString()))
+	{
+		ProjectNames.Empty();
+
+		// Launch an asynchronous GetProjects operation
+		TSharedRef<FPlasticGetProjects, ESPMode::ThreadSafe> GetProjectsOperation = ISourceControlOperation::Create<FPlasticGetProjects>();
+		GetProjectsOperation->ServerUrl = WorkspaceParams.ServerUrl.ToString();
+		FPlasticSourceControlProvider& Provider = FPlasticSourceControlModule::Get().GetProvider();
+		ECommandResult::Type Result = Provider.Execute(GetProjectsOperation, TArray<FString>(), EConcurrency::Asynchronous, FSourceControlOperationComplete::CreateRaw(this, &SPlasticSourceControlSettings::OnGetProjectsOperationComplete));
+		if (Result == ECommandResult::Succeeded)
+		{
+			bGetProjectsInProgress = true;
+		}
+	}
+}
+void SPlasticSourceControlSettings::OnGetProjectsOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult)
+{
+	bGetProjectsInProgress = false;
+
+	if (InResult == ECommandResult::Succeeded)
+	{
+		TSharedRef<FPlasticGetProjects, ESPMode::ThreadSafe> GetProjectsOperation = StaticCastSharedRef<FPlasticGetProjects>(InOperation);
+
+		UE_LOG(LogSourceControl, Verbose, TEXT("OnGetProjectsOperationComplete: %d projects in %s"), GetProjectsOperation->ProjectNames.Num(), *GetProjectsOperation->ServerUrl);
+
+		ProjectNames.Reserve(GetProjectsOperation->ProjectNames.Num());
+		for (FString& Project : GetProjectsOperation->ProjectNames)
+		{
+			ProjectNames.Add(FText::FromString(Project));
+		}
+		WorkspaceParams.ProjectName = ProjectNames[0];
+	}
+}
+
+FText SPlasticSourceControlSettings::GetProjectName() const
+{
+	return WorkspaceParams.ProjectName;
+}
+void SPlasticSourceControlSettings::OnProjectSelected(const FText InProjectName)
+{
+	WorkspaceParams.ProjectName = InProjectName;
+}
+TSharedRef<SWidget> SPlasticSourceControlSettings::BuildProjectDropDownMenu()
+{
+	FMenuBuilder MenuBuilder(true, NULL);
+
+	for (const FText& ProjectName : ProjectNames)
+	{
+		FUIAction MenuAction(FExecuteAction::CreateSP(this, &SPlasticSourceControlSettings::OnProjectSelected, ProjectName));
+		MenuBuilder.AddMenuEntry(ProjectName, ProjectName, FSlateIcon(), MenuAction);
+	}
+
+	return MenuBuilder.MakeWidget();
 }
 
 void SPlasticSourceControlSettings::OnRepositoryNameCommited(const FText& InText, ETextCommit::Type InCommitType)
@@ -533,13 +819,13 @@ FText SPlasticSourceControlSettings::GetRepositoryName() const
 	return WorkspaceParams.RepositoryName;
 }
 
-void SPlasticSourceControlSettings::OnServerUrlCommited(const FText& InText, ETextCommit::Type InCommitType)
+void SPlasticSourceControlSettings::OnWorkspaceNameCommited(const FText& InText, ETextCommit::Type InCommitType)
 {
-	WorkspaceParams.ServerUrl = InText;
+	WorkspaceParams.WorkspaceName = InText;
 }
-FText SPlasticSourceControlSettings::GetServerUrl() const
+FText SPlasticSourceControlSettings::GetWorkspaceName() const
 {
-	return WorkspaceParams.ServerUrl;
+	return WorkspaceParams.WorkspaceName;
 }
 
 bool SPlasticSourceControlSettings::CreatePartialWorkspace() const
@@ -581,8 +867,8 @@ FText SPlasticSourceControlSettings::GetInitialCommitMessage() const
 
 FReply SPlasticSourceControlSettings::OnClickedCreatePlasticWorkspace()
 {
-	UE_LOG(LogSourceControl, Log, TEXT("CreatePlasticWorkspace(%s, %s, %s) PartialWorkspace=%d CreateIgnore=%d Commit=%d"),
-		*WorkspaceParams.WorkspaceName.ToString(), *WorkspaceParams.RepositoryName.ToString(), *WorkspaceParams.ServerUrl.ToString(),
+	UE_LOG(LogSourceControl, Log, TEXT("CreatePlasticWorkspace(%s, %s, %s, %s) PartialWorkspace=%d CreateIgnore=%d Commit=%d"),
+		*WorkspaceParams.ServerUrl.ToString(), *WorkspaceParams.ProjectName.ToString(), *WorkspaceParams.RepositoryName.ToString(), *WorkspaceParams.WorkspaceName.ToString(),
 		WorkspaceParams.bCreatePartialWorkspace, bAutoCreateIgnoreFile, WorkspaceParams.bAutoInitialCommit);
 
 	if (bAutoCreateIgnoreFile)

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.h
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlSettings.h
@@ -8,6 +8,7 @@
 #include "Layout/Visibility.h"
 #include "Input/Reply.h"
 #include "Styling/SlateTypes.h"
+#include "ISourceControlOperation.h"
 
 #include "PlasticSourceControlWorkspaceCreation.h"
 
@@ -36,14 +37,36 @@ private:
 	FText GetUserName() const;
 
 	/** Delegate to create a new Plastic workspace and repository */
+	EVisibility IsWorkspaceFound() const;
 	EVisibility CanCreatePlasticWorkspace() const;
 	bool IsReadyToCreatePlasticWorkspace() const;
-	void OnWorkspaceNameCommited(const FText& InText, ETextCommit::Type InCommitType);
-	FText GetWorkspaceName() const;
+
+	FText GetRepositorySpec() const;
+
+	// Server/Organization, Project, Repository, Workspace names
+	EVisibility CanSelectServer() const;
+	EVisibility NoServerToSelect() const;
+	FText GetServerUrl() const;
+	TSharedRef<SWidget> BuildServerDropDownMenu();
+	void OnServerSelected(const FText InServerName);
+	void OnGetProjectsOperationComplete(const FSourceControlOperationRef& InOperation, ECommandResult::Type InResult);
+	TArray<FText> ServerNames;
+
+	bool bGetProjectsInProgress;
+
+	EVisibility CanSelectProject() const;
+	EVisibility NoProjectToSelect() const;
+	FText GetProjectName() const;
+	TSharedRef<SWidget> BuildProjectDropDownMenu();
+	void OnProjectSelected(const FText InProjectName);
+	TArray<FText> ProjectNames;
+
 	void OnRepositoryNameCommited(const FText& InText, ETextCommit::Type InCommitType);
 	FText GetRepositoryName() const;
-	void OnServerUrlCommited(const FText& InText, ETextCommit::Type InCommitType);
-	FText GetServerUrl() const;
+
+	void OnWorkspaceNameCommited(const FText& InText, ETextCommit::Type InCommitType);
+	FText GetWorkspaceName() const;
+
 	bool CreatePartialWorkspace() const;
 	void OnCheckedCreatePartialWorkspace(ECheckBoxState NewCheckedState);
 	bool CanAutoCreateIgnoreFile() const;


### PR DESCRIPTION
Rework the create workspace to improve it's usability and onboarding:
- Revert the UI order in the order of selection: Server/Organization, Project, Repository, Workspace names
- Dropdown to select the server from the list of configured profiles: no more free form as they need to be configured properly beforehand with the Desktop application anyway
- Display the user name corresponding to the server
- Dropdown to select the project if the server is a Unity Organization
- Move the "cm" input field and make it smaller
- Move away advanced runtime settings into a expandable area folded by default

