### PR TITLE
Fix 'cm checkconnection' to never call it with a --server argument that creates issues with authentication

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -354,7 +354,10 @@ bool RunCheckConnection(FString& OutWorkspaceSelector, FString& OutBranchName, F
 	TArray<FString> Parameters;
 	if (PlasticSourceControlUtils::GetWorkspaceInfo(OutWorkspaceSelector, OutBranchName, OutRepositoryName, OutServerUrl, OutErrorMessages))
 	{
-		Parameters.Add(FString::Printf(TEXT("--server=%s"), *OutServerUrl));
+		if ((FPlasticSourceControlModule::Get().GetProvider().GetPlasticScmVersion() >= PlasticSourceControlVersions::CheckConnection))
+		{
+			Parameters.Add(OutServerUrl);
+		}
 	}
 	return PlasticSourceControlUtils::RunCommand(TEXT("checkconnection"), Parameters, TArray<FString>(), OutInfoMessages, OutErrorMessages);
 }

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlVersions.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlVersions.h
@@ -56,4 +56,8 @@ namespace PlasticSourceControlVersions
 	// https://plasticscm.com/download/releasenotes/11.0.16.8445 (2024/02/22)
 	static const FSoftwareVersion WorkingBranch(TEXT("11.0.16.8445"));
 
+	// 11.0.16.9055 checkconnection learned a new optional argument <repserverspec>.
+	// https://plasticscm.com/download/releasenotes/11.0.16.9055 (2024/11/28)
+	static const FSoftwareVersion CheckConnection(TEXT("11.0.16.9055"));
+
 } // namespace PlasticSourceControlVersions


### PR DESCRIPTION
Implement a fix requiring a new version of cm >= 11.0.16.9039, calling `cm checkconnection <server>` instead of `--server=<server>`
If the installed version of Unity Version Control is older than that the fallback is to call `cm checkconnection` with not any argument.

The downside is that, for users with an older version of Unity Version Control, and using Unreal with a server that is not their default server configured in the client.conf, it will check connection to the wrong server, but it's much better than just failing the auth renewal like it did for many years!

Fixes

- https://github.com/SRombauts/UEPlasticPlugin/issues/146
- https://github.com/SRombauts/UEPlasticPlugin/issues/142