### PR TITLE
Update cm checkconnection to only use the new <repserver> argument starting with 11.0.16.9080

### DIFF
--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -359,7 +359,7 @@ bool RunCheckConnection(FString& OutWorkspaceSelector, FString& OutBranchName, F
 	TArray<FString> Parameters;
 	if (PlasticSourceControlUtils::GetWorkspaceInfo(OutWorkspaceSelector, OutBranchName, OutRepositoryName, OutServerUrl, OutErrorMessages))
 	{
-		if ((FPlasticSourceControlModule::Get().GetProvider().GetPlasticScmVersion() >= PlasticSourceControlVersions::CheckConnection) && !IsUnityOrganization(OutServerUrl))
+		if ((FPlasticSourceControlModule::Get().GetProvider().GetPlasticScmVersion() >= PlasticSourceControlVersions::CheckConnectionRepServer) && !IsUnityOrganization(OutServerUrl))
 		{
 			Parameters.Add(OutServerUrl);
 		}

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlUtils.cpp
@@ -359,7 +359,7 @@ bool RunCheckConnection(FString& OutWorkspaceSelector, FString& OutBranchName, F
 	TArray<FString> Parameters;
 	if (PlasticSourceControlUtils::GetWorkspaceInfo(OutWorkspaceSelector, OutBranchName, OutRepositoryName, OutServerUrl, OutErrorMessages))
 	{
-		if ((FPlasticSourceControlModule::Get().GetProvider().GetPlasticScmVersion() >= PlasticSourceControlVersions::CheckConnectionRepServer) && !IsUnityOrganization(OutServerUrl))
+		if ((FPlasticSourceControlModule::Get().GetProvider().GetPlasticScmVersion() >= PlasticSourceControlVersions::CheckConnectionRepServer))
 		{
 			Parameters.Add(OutServerUrl);
 		}

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlVersions.h
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlVersions.h
@@ -56,8 +56,8 @@ namespace PlasticSourceControlVersions
 	// https://plasticscm.com/download/releasenotes/11.0.16.8445 (2024/02/22)
 	static const FSoftwareVersion WorkingBranch(TEXT("11.0.16.8445"));
 
-	// 11.0.16.9055 checkconnection learned a new optional argument <repserverspec>.
-	// https://plasticscm.com/download/releasenotes/11.0.16.9055 (2024/11/28)
-	static const FSoftwareVersion CheckConnection(TEXT("11.0.16.9055"));
+	// 11.0.16.9080 checkconnection new optional argument <repserverspec> (fixed for @unity orgs)
+	// https://plasticscm.com/download/releasenotes/11.0.16.9080 (2024/12/12)
+	static const FSoftwareVersion CheckConnectionRepServer(TEXT("11.0.16.9080"));
 
 } // namespace PlasticSourceControlVersions


### PR DESCRIPTION
- Update PlasticSourceControlVersions::CheckConnectionRepServer from version 11.0.16.9055 (bugged for @unity orgs) to new version 11.0.16.9080
- Remove workaround in PlasticSourceControlUtils::RunCheckConnection() that was checking for @unity org to avoid using the <repserver> argument for @unity organizations