### PR TITLE
Fix localization warnings introduced by [Source Control] Update Plastic SCM provider to 1.11.0 (from 1.9.0) #12084

### DIFF
--- a/Source/PlasticSourceControl/Private/Notification.cpp
+++ b/Source/PlasticSourceControl/Private/Notification.cpp
@@ -121,7 +121,7 @@ void FNotification::DisplayFailure(const FSourceControlOperationBase& InOperatio
 	{
 		// If there are multiple messages, display the last one to not let the user with a notification starting with a "wait" or "in progress" message
 		const FText NotificationText = FText::Format(
-			LOCTEXT("PlasticSourceControlOperation_Failure", "Error: {0} operation failed!\n{1}"),
+			LOCTEXT("PlasticSourceControlOperation_FailureWithMessages", "Error: {0} operation failed!\n{1}"),
 			FText::FromName(InOperation.GetName()),
 			InOperation.GetResultInfo().ErrorMessages.Last()
 		);

--- a/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
+++ b/Source/PlasticSourceControl/Private/PlasticSourceControlState.cpp
@@ -26,8 +26,8 @@ const TCHAR* FPlasticSourceControlState::ToString() const
 		case EWorkspaceState::Moved: return TEXT("Moved");
 		case EWorkspaceState::Copied: return TEXT("Copied");
 		case EWorkspaceState::Replaced: return TEXT("Replaced");
-		case EWorkspaceState::Deleted: return TEXT("Deleted");
-		case EWorkspaceState::LocallyDeleted: return TEXT("LocallyDeleted");
+		case EWorkspaceState::Deleted: return TEXT("Removed");
+		case EWorkspaceState::LocallyDeleted: return TEXT("Deleted locally");
 		case EWorkspaceState::Changed: return TEXT("Changed");
 		case EWorkspaceState::Conflicted: return TEXT("Conflicted");
 		case EWorkspaceState::Private: return TEXT("Private");
@@ -46,8 +46,8 @@ FText FPlasticSourceControlState::ToText() const
 	static const FText Moved = LOCTEXT("Moved", "Moved");
 	static const FText Copied = LOCTEXT("Copied", "Copied");
 	static const FText Replaced = LOCTEXT("Replaced", "Replaced");
-	static const FText Deleted = LOCTEXT("Deleted", "Deleted");
-	static const FText LocallyDeleted = LOCTEXT("LocallyDeleted", "LocallyDeleted");
+	static const FText Deleted = LOCTEXT("Deleted", "Removed");
+	static const FText LocallyDeleted = LOCTEXT("LocallyDeleted", "Deleted locally");
 	static const FText Changed = LOCTEXT("Changed", "Changed");
 	static const FText Conflicted = LOCTEXT("Conflicted", "Conflicted");
 	static const FText Private = LOCTEXT("Private", "Private");

--- a/Source/PlasticSourceControl/Private/SPlasticSourceControlChangesetsWidget.cpp
+++ b/Source/PlasticSourceControl/Private/SPlasticSourceControlChangesetsWidget.cpp
@@ -1029,7 +1029,7 @@ TSharedPtr<SWidget> SPlasticSourceControlChangesetsWidget::OnOpenChangesetContex
 	Section.AddMenuEntry(
 		"DiffChangesets",
 		LOCTEXT("DiffChangesets", "Diff selected changesets"),
-		bDoubleSelection ? LOCTEXT("DiffChangesetTooltip", "Launch the Desktop application diff window showing changes between the two selected changesets.") : LOCTEXT("DoubleSelection", "Select a couple of changesets."),
+		bDoubleSelection ? LOCTEXT("DiffChangesetsTooltip", "Launch the Desktop application diff window showing changes between the two selected changesets.") : LOCTEXT("DoubleSelection", "Select a couple of changesets."),
 		FSlateIcon(),
 		FUIAction(
 			FExecuteAction::CreateSP(this, &SPlasticSourceControlChangesetsWidget::OnDiffChangesetsClicked, SelectedChangesets),
@@ -1042,7 +1042,7 @@ TSharedPtr<SWidget> SPlasticSourceControlChangesetsWidget::OnOpenChangesetContex
 	Section.AddMenuEntry(
 		"DiffBranch",
 		bSingleBranchSelected ? FText::Format(LOCTEXT("DiffBranchDynamic", "Diff branch {0}"), FText::FromString(SelectedChangeset->Branch)) : LOCTEXT("DiffBranch", "Diff branch"),
-		bSingleBranchSelected ? LOCTEXT("DiffChangesetTooltip", "Launch the Desktop application diff window showing all changes in the selected branch.") : SelectASingleBranchTooltip,
+		bSingleBranchSelected ? LOCTEXT("DiffBranchTooltip", "Launch the Desktop application diff window showing all changes in the selected branch.") : SelectASingleBranchTooltip,
 		FSlateIcon(),
 		FUIAction(
 			FExecuteAction::CreateSP(this, &SPlasticSourceControlChangesetsWidget::OnDiffBranchClicked, SelectedChangeset),


### PR DESCRIPTION
Fix localization warnings introduced by https://github.com/EpicGames/UnrealEngine/pull/12084 [Source Control] Update Plastic SCM provider to 1.11.0 (from 1.9.0) #12084

- Fix the 2 warnings in PlasticSourceControlState.cpp using the more recent wording
- Fix the 2 warnings in SPlasticSourceControlChangesetsWidget.cpp by renaming 2 of the 3 conflicting keys so the 3 are now uniques